### PR TITLE
Fix #3 and #6: per-book download folders and reliable missing-part recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 libby_config.json
+libby_run.log
+logs/
+snapshots/
 Libby_Audiobook_Downloads/
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+libby_config.json
+Libby_Audiobook_Downloads/
+__pycache__/
+*.pyc

--- a/libby_download.py
+++ b/libby_download.py
@@ -593,11 +593,25 @@ def run():
                 print(f"An error occurred while listing/selecting audiobooks: {e}")
                 return
 
-            print("Audiobook player opened. Starting part discovery...")
-            time.sleep(5) # Give player time to load initial parts and for network requests to fire
+            print("Audiobook player opened. Rewinding to beginning...")
+            time.sleep(5)
             screenshot_path = os.path.join(config['DOWNLOAD_DIRECTORY'], "16_after_audiobook_detail_load.png")
             page.screenshot(path=screenshot_path)
 
+            # Navigate to the beginning of the book so the forward pass starts from Part 1
+            try:
+                player_frame_init = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+                for rewind_i in range(50):
+                    try:
+                        prev_btn = player_frame_init.locator('button[aria-label*="Previous Chapter"]')
+                        prev_btn.first.click(timeout=2000)
+                        time.sleep(0.5)
+                    except (PlaywrightTimeoutError, Exception):
+                        print(f"Reached beginning of book after {rewind_i} Previous Chapter clicks.")
+                        break
+                time.sleep(3)
+            except Exception as e:
+                print(f"Error rewinding to beginning: {e}")
 
             # --- Step 3: Player Control and Forward Part Discovery ---
             initial_parts_count = len(downloaded_parts)
@@ -989,31 +1003,45 @@ def run():
                         except Exception as e:
                             print(f"  Signed URL fetch failed: {e}")
 
-                    # Method 2: Chapter navigation fallback
-                    if missing_part not in downloaded_parts:
-                        print(f"  Trying chapter navigation for Part {missing_part}...")
-                        player_fl = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
-                        PREV_SELS = ['button[aria-label*="Previous Chapter"]', 'button[aria-label*="Previous chapter"]']
-                        for attempt in range(3):
-                            try:
-                                for _ in range(2):
-                                    for sel in PREV_SELS:
-                                        try:
-                                            player_fl.locator(sel).first.click(timeout=3000)
-                                            time.sleep(1)
-                                            break
-                                        except (PlaywrightTimeoutError, Exception):
-                                            continue
-                                time.sleep(5)
-                                if missing_part in downloaded_parts:
-                                    break
-                            except Exception as e:
-                                print(f"  Chapter nav attempt {attempt+1} failed: {e}")
-
                     if missing_part in downloaded_parts:
                         print(f"  Successfully retrieved Part {missing_part}!")
                     else:
                         print(f"  Failed to retrieve Part {missing_part}.")
+
+                # Method 2: Systematic forward scan from beginning for remaining missing parts
+                still_missing = [p for p in missing_parts if p not in downloaded_parts]
+                if still_missing:
+                    print(f"\nSystematic scan for {len(still_missing)} remaining missing parts: {still_missing}")
+                    player_fl = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+
+                    print("  Rewinding to beginning...")
+                    for _ in range(50):
+                        try:
+                            player_fl.locator('button[aria-label*="Previous Chapter"]').first.click(timeout=2000)
+                            time.sleep(0.5)
+                        except (PlaywrightTimeoutError, Exception):
+                            break
+                    time.sleep(3)
+
+                    print("  Scanning forward through all chapters...")
+                    for scan_i in range(100):
+                        remaining = [p for p in still_missing if p not in downloaded_parts]
+                        if not remaining:
+                            print(f"  All missing parts found after {scan_i} chapter scans!")
+                            break
+                        try:
+                            player_fl.locator('button[aria-label*="Next Chapter"]').first.click(timeout=3000)
+                            time.sleep(3)
+                            newly_found = [p for p in still_missing if p in downloaded_parts and p not in found_parts]
+                        except (PlaywrightTimeoutError, Exception):
+                            print(f"  End of book reached after {scan_i} chapter scans.")
+                            break
+
+                    final_missing = [p for p in missing_parts if p not in downloaded_parts]
+                    if final_missing:
+                        print(f"  Parts still missing after full scan: {final_missing}")
+                    else:
+                        print(f"  All parts successfully retrieved!")
 
             print("All download attempts complete.")
 

--- a/libby_download.py
+++ b/libby_download.py
@@ -193,7 +193,7 @@ def run():
     config = load_config()
 
     # Playwright Browser Settings - now uses HEADLESS_MODE from config
-    HEADLESS_MODE = True # Keep this as False for debugging, can be moved to config later if desired
+    HEADLESS_MODE = False # Keep this as False for debugging, can be moved to config later if desired
 
     # Initialize Playwright with the stealth plugin
     with Stealth().use_sync(sync_playwright()) as p:
@@ -879,6 +879,9 @@ def run():
                             'button[aria-label*="Previous Chapter"]',
                             'button[aria-label*="Previous chapter"]',
                             'button[aria-label*="previous chapter"]',
+                            'button[aria-label*="revious"]',
+                            'button[aria-label*="Back"]',
+                            'button[aria-label*="back"]',
                             'button.chapter-bar-prev-button',
                         ]
 
@@ -899,6 +902,18 @@ def run():
                                 except (PlaywrightTimeoutError, Exception):
                                     continue
                             if not clicked_prev:
+                                try:
+                                    all_btns = player_frame.locator('button').all()
+                                    print(f"  DEBUG: {len(all_btns)} buttons in player iframe:")
+                                    for idx, btn in enumerate(all_btns):
+                                        try:
+                                            label = btn.get_attribute('aria-label') or ''
+                                            cls = btn.get_attribute('class') or ''
+                                            print(f"    btn[{idx}] aria-label='{label}' class='{cls}'")
+                                        except Exception:
+                                            pass
+                                except Exception as e:
+                                    print(f"  DEBUG: Could not enumerate iframe buttons: {e}")
                                 print(f"  Could not find Previous Chapter button with any selector.")
                                 break
 

--- a/libby_download.py
+++ b/libby_download.py
@@ -20,6 +20,7 @@ max_part_number_found = 0
 active_downloads_lock = threading.Lock()
 active_downloads_count = 0
 _latest_libby_part_number_trigger = None # Global variable to store the last part number seen in a Libby URL
+_libby_url_template = None # Captured from first part trigger, used to construct URLs for missing parts
 
 # --- Configuration Management Functions ---
 def load_config():
@@ -78,7 +79,7 @@ def handle_request(request):
     Callback function to process intercepted network requests.
     Identifies and downloads audiobook MP3 parts directly using requests library.
     """
-    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger
+    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger, _libby_url_template
 
     # Case 1: Intercept initial Libby part request (contains PartXX.mp3)
     # This request triggers the playback and sets up the session for the CDN download.
@@ -86,9 +87,12 @@ def handle_request(request):
         part_match = re.search(r"Part(\d+).mp3", request.url, re.IGNORECASE)
         if part_match:
             part_number = int(part_match.group(1))
-            with active_downloads_lock:  # Protect access to global trigger and found_parts
+            with active_downloads_lock:
                 _latest_libby_part_number_trigger = part_number
-                found_parts.add(part_number)  # Record part as soon as triggered (before download completes)
+                found_parts.add(part_number)
+                if _libby_url_template is None:
+                    _libby_url_template = re.sub(r'Part\d+\.mp3\?cmpt=.*', '', request.url)
+                    print(f"Captured Libby URL template: {_libby_url_template}")
             print(f"Detected Libby part trigger: {request.url} -> Set _latest_libby_part_number_trigger to {part_number}")
             # Do NOT attempt to get response body here, as it's typically empty or a redirect trigger.
             # We are just capturing the part number for the subsequent CDN request.
@@ -867,73 +871,9 @@ def run():
 
                     break # Exit loop if button is not found (likely end of book)
 
-                # If we clicked Next Chapter, ensure we didn't skip a part (audio parts can be shorter than chapters)
-                if button_found:
-                    time.sleep(2)
-                    max_found = max(found_parts) if found_parts else 0
-                    if expected_next_part not in found_parts and max_found >= expected_next_part:
-                        print(f"Gap detected: expected part {expected_next_part} but have part(s) up to {max_found}. Going back to find part {expected_next_part}...")
-                        player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
-
-                        PREV_CHAPTER_SELECTORS = [
-                            'button[aria-label*="Previous Chapter"]',
-                            'button[aria-label*="Previous chapter"]',
-                            'button[aria-label*="previous chapter"]',
-                            'button[aria-label*="revious"]',
-                            'button.chapter-bar-prev-button',
-                        ]
-                        ADVANCE_WAIT_SEC = 1
-
-                        prev_chapter_clicks = 0
-                        total_advance_clicks = 0
-                        max_prev_chapters = 5
-                        max_advances_per_round = 120
-
-                        while expected_next_part not in found_parts and prev_chapter_clicks < max_prev_chapters:
-                            # Go back one chapter
-                            clicked_prev = False
-                            for sel in PREV_CHAPTER_SELECTORS:
-                                try:
-                                    player_frame.locator(sel).first.click(timeout=3000)
-                                    clicked_prev = True
-                                    prev_chapter_clicks += 1
-                                    print(f"  Previous Chapter {prev_chapter_clicks}/{max_prev_chapters}")
-                                    time.sleep(3)
-                                    break
-                                except (PlaywrightTimeoutError, Exception):
-                                    continue
-
-                            if not clicked_prev:
-                                print(f"  Could not find Previous Chapter button.")
-                                break
-
-                            if expected_next_part in found_parts:
-                                break
-
-                            # Advance 15s at a time through this chapter to find the part
-                            advances_this_round = 0
-                            while expected_next_part not in found_parts and advances_this_round < max_advances_per_round:
-                                try:
-                                    player_frame.locator('button[aria-label*="Advance 15 seconds"]').first.click(timeout=3000)
-                                    advances_this_round += 1
-                                    total_advance_clicks += 1
-                                    if advances_this_round % 20 == 0:
-                                        print(f"    Advance 15s: {advances_this_round}/{max_advances_per_round} (total: {total_advance_clicks})")
-                                    time.sleep(ADVANCE_WAIT_SEC)
-                                except (PlaywrightTimeoutError, Exception) as e:
-                                    print(f"    Advance click failed: {e}")
-                                    break
-
-                            if expected_next_part in found_parts:
-                                break
-
-                            print(f"  Part {expected_next_part} not found after {advances_this_round} advances in this chapter. Going back further...")
-
-                        if expected_next_part in found_parts:
-                            print(f"  Found part {expected_next_part} after {prev_chapter_clicks} prev-chapter + {total_advance_clicks} advances.")
-                            time.sleep(3)
-                        else:
-                            print(f"  Part {expected_next_part} not found after {prev_chapter_clicks} prev-chapter + {total_advance_clicks} advances.")
+                # Note: chapters span multiple audio parts, so chapter navigation
+                # will skip parts that fall mid-chapter. These are handled in Step 4
+                # using direct spine navigation instead of the slow button-click approach.
 
                 if len(downloaded_parts) == current_parts_count:
                     no_new_parts_count += 1
@@ -958,7 +898,7 @@ def run():
                 print(f"Still {current_active} downloads active. Waiting...")
                 time.sleep(5) # Wait a bit before checking again
 
-            # --- Step 4: Handling Missing Parts (Backward Seeking) ---
+            # --- Step 4: Retrieve Missing Parts via Direct Spine Navigation ---
             print("Checking for any missing parts and attempting to retrieve them...")
             missing_parts = []
             for i in range(1, max_part_number_found + 1):
@@ -969,45 +909,112 @@ def run():
                 print("No missing parts detected. All parts downloaded successfully!")
             else:
                 print(f"Missing parts identified: {sorted(missing_parts)}")
-                PREV_CHAPTER_SELECTORS_STEP4 = [
-                    'button[aria-label*="Previous Chapter"]',
-                    'button[aria-label*="Previous chapter"]',
-                    'button[aria-label*="previous chapter"]',
-                    'button.chapter-bar-prev-button',
-                ]
-                player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+
+                player_frame_obj = None
+                for frame in page.frames:
+                    if 'listen.libbyapp.com' in frame.url:
+                        player_frame_obj = frame
+                        break
 
                 for missing_part in sorted(missing_parts):
-                    print(f"Attempting to retrieve missing Part {missing_part}...")
-                    retries = 3
-                    for attempt in range(retries):
+                    if missing_part in downloaded_parts:
+                        continue
+                    print(f"Attempting to retrieve missing Part {missing_part} (spine {missing_part - 1})...")
+
+                    navigated = False
+                    if player_frame_obj:
                         try:
-                            for _ in range(2):
-                                clicked = False
-                                for sel in PREV_CHAPTER_SELECTORS_STEP4:
-                                    try:
-                                        player_frame.locator(sel).first.click(timeout=3000)
-                                        clicked = True
-                                        time.sleep(1)
-                                        break
-                                    except (PlaywrightTimeoutError, Exception):
-                                        continue
-                                if not clicked:
-                                    print("Reached beginning of audiobook while seeking backwards.")
-                                    break
-
-                            print(f"Attempt {attempt + 1} to trigger Part {missing_part} download...")
-                            time.sleep(5) # Give ample time for network requests
-
-                            if missing_part in downloaded_parts:
-                                print(f"Successfully retrieved missing Part {missing_part}!")
-                                break # Move to the next missing part
-                            else:
-                                print(f"Part {missing_part} not found after attempt {attempt + 1}.")
+                            result = player_frame_obj.evaluate("""
+                                (spineIndex) => {
+                                    try {
+                                        // OverDrive reader: try common API patterns
+                                        if (typeof bif !== 'undefined' && bif.player) {
+                                            bif.player.openSpine(spineIndex);
+                                            return {success: true, method: 'bif.player.openSpine'};
+                                        }
+                                        // Try window.player
+                                        if (window.player && window.player.openSpine) {
+                                            window.player.openSpine(spineIndex);
+                                            return {success: true, method: 'window.player.openSpine'};
+                                        }
+                                        // Try _roState / redux store
+                                        if (window.__NEXT_DATA__ || window.__store__) {
+                                            return {success: false, method: 'store found but no navigate'};
+                                        }
+                                        // Enumerate global objects that might be the player
+                                        var playerKeys = [];
+                                        for (var key in window) {
+                                            try {
+                                                if (window[key] && typeof window[key] === 'object' &&
+                                                    (window[key].openSpine || window[key].goToSpine ||
+                                                     window[key].loadSpine || window[key].playSpine)) {
+                                                    playerKeys.push(key);
+                                                }
+                                            } catch(e) {}
+                                        }
+                                        if (playerKeys.length > 0) {
+                                            return {success: false, method: 'found objects: ' + playerKeys.join(',')};
+                                        }
+                                        return {success: false, method: 'no player API found'};
+                                    } catch(e) {
+                                        return {success: false, error: e.message};
+                                    }
+                                }
+                            """, missing_part - 1)
+                            print(f"  JS spine navigation result: {result}")
+                            if result.get('success'):
+                                navigated = True
+                                time.sleep(5)
                         except Exception as e:
-                            print(f"Error during backward seeking for Part {missing_part}: {e}")
+                            print(f"  JS spine navigation failed: {e}")
+
+                    if not navigated and _libby_url_template:
+                        import base64 as b64
+                        spine_json = json.dumps({"spine": missing_part - 1})
+                        cmpt_unsigned = b64.b64encode(spine_json.encode()).decode()
+                        part_url = f"{_libby_url_template}Part{missing_part:02d}.mp3?cmpt={cmpt_unsigned}"
+                        print(f"  Trying direct URL fetch for Part {missing_part}...")
+                        try:
+                            if player_frame_obj:
+                                player_frame_obj.evaluate(f"""
+                                    (url) => {{
+                                        var audio = new Audio();
+                                        audio.src = url;
+                                        audio.load();
+                                    }}
+                                """, part_url)
+                                time.sleep(5)
+                            page.evaluate(f"""
+                                (url) => fetch(url, {{mode: 'no-cors'}}).catch(() => {{}})
+                            """, part_url)
+                            time.sleep(5)
+                        except Exception as e:
+                            print(f"  Direct URL fetch failed: {e}")
+
                     if missing_part not in downloaded_parts:
-                        print(f"Failed to retrieve Part {missing_part} after {retries} attempts.")
+                        print(f"  Trying chapter navigation fallback for Part {missing_part}...")
+                        player_fl = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+                        PREV_SELS = ['button[aria-label*="Previous Chapter"]', 'button[aria-label*="Previous chapter"]']
+                        for attempt in range(3):
+                            try:
+                                for _ in range(2):
+                                    for sel in PREV_SELS:
+                                        try:
+                                            player_fl.locator(sel).first.click(timeout=3000)
+                                            time.sleep(1)
+                                            break
+                                        except (PlaywrightTimeoutError, Exception):
+                                            continue
+                                time.sleep(5)
+                                if missing_part in downloaded_parts:
+                                    break
+                            except Exception as e:
+                                print(f"  Chapter nav attempt {attempt+1} failed: {e}")
+
+                    if missing_part in downloaded_parts:
+                        print(f"  Successfully retrieved Part {missing_part}!")
+                    else:
+                        print(f"  Failed to retrieve Part {missing_part}.")
 
             print("All download attempts complete.")
 

--- a/libby_download.py
+++ b/libby_download.py
@@ -880,76 +880,60 @@ def run():
                             'button[aria-label*="Previous chapter"]',
                             'button[aria-label*="previous chapter"]',
                             'button[aria-label*="revious"]',
-                            'button[aria-label*="Back"]',
-                            'button[aria-label*="back"]',
                             'button.chapter-bar-prev-button',
                         ]
+                        ADVANCE_WAIT_SEC = 1
 
-                        # Step 1: Jump back using "Previous Chapter" (much faster than 15s rewinds)
                         prev_chapter_clicks = 0
+                        total_advance_clicks = 0
                         max_prev_chapters = 5
+                        max_advances_per_round = 120
+
                         while expected_next_part not in found_parts and prev_chapter_clicks < max_prev_chapters:
+                            # Go back one chapter
                             clicked_prev = False
                             for sel in PREV_CHAPTER_SELECTORS:
                                 try:
-                                    prev_btn = player_frame.locator(sel)
-                                    prev_btn.first.click(timeout=3000)
+                                    player_frame.locator(sel).first.click(timeout=3000)
                                     clicked_prev = True
                                     prev_chapter_clicks += 1
-                                    print(f"  Previous Chapter {prev_chapter_clicks}/{max_prev_chapters} (selector: {sel})")
-                                    time.sleep(5)
+                                    print(f"  Previous Chapter {prev_chapter_clicks}/{max_prev_chapters}")
+                                    time.sleep(3)
                                     break
                                 except (PlaywrightTimeoutError, Exception):
                                     continue
+
                             if not clicked_prev:
-                                try:
-                                    all_btns = player_frame.locator('button').all()
-                                    print(f"  DEBUG: {len(all_btns)} buttons in player iframe:")
-                                    for idx, btn in enumerate(all_btns):
-                                        try:
-                                            label = btn.get_attribute('aria-label') or ''
-                                            cls = btn.get_attribute('class') or ''
-                                            print(f"    btn[{idx}] aria-label='{label}' class='{cls}'")
-                                        except Exception:
-                                            pass
-                                except Exception as e:
-                                    print(f"  DEBUG: Could not enumerate iframe buttons: {e}")
-                                print(f"  Could not find Previous Chapter button with any selector.")
+                                print(f"  Could not find Previous Chapter button.")
                                 break
 
-                        if expected_next_part in downloaded_parts:
-                            print(f"  Found part {expected_next_part} after {prev_chapter_clicks} Previous Chapter click(s).")
+                            if expected_next_part in found_parts:
+                                break
+
+                            # Advance 15s at a time through this chapter to find the part
+                            advances_this_round = 0
+                            while expected_next_part not in found_parts and advances_this_round < max_advances_per_round:
+                                try:
+                                    player_frame.locator('button[aria-label*="Advance 15 seconds"]').first.click(timeout=3000)
+                                    advances_this_round += 1
+                                    total_advance_clicks += 1
+                                    if advances_this_round % 20 == 0:
+                                        print(f"    Advance 15s: {advances_this_round}/{max_advances_per_round} (total: {total_advance_clicks})")
+                                    time.sleep(ADVANCE_WAIT_SEC)
+                                except (PlaywrightTimeoutError, Exception) as e:
+                                    print(f"    Advance click failed: {e}")
+                                    break
+
+                            if expected_next_part in found_parts:
+                                break
+
+                            print(f"  Part {expected_next_part} not found after {advances_this_round} advances in this chapter. Going back further...")
+
+                        if expected_next_part in found_parts:
+                            print(f"  Found part {expected_next_part} after {prev_chapter_clicks} prev-chapter + {total_advance_clicks} advances.")
+                            time.sleep(3)
                         else:
-                            # Step 2: If Previous Chapter worked, advance 15s to find exact part boundary.
-                            # If Previous Chapter failed, rewind 15s as fallback.
-                            if prev_chapter_clicks > 0:
-                                advance_clicks = 0
-                                while expected_next_part not in downloaded_parts and advance_clicks < MAX_REWIND_CLICKS:
-                                    try:
-                                        advance_btn = player_frame.locator('button[aria-label*="Advance 15 seconds"]')
-                                        advance_btn.first.click(timeout=3000)
-                                        advance_clicks += 1
-                                        print(f"  Advance 15s {advance_clicks}/{MAX_REWIND_CLICKS} (looking for part {expected_next_part})")
-                                        time.sleep(REWIND_WAIT_SEC)
-                                    except (PlaywrightTimeoutError, Exception) as e:
-                                        print(f"  Advance click failed: {e}")
-                                        break
-                                status = "found" if expected_next_part in downloaded_parts else "not found"
-                                print(f"  Part {expected_next_part} {status} after {prev_chapter_clicks} prev-chapter + {advance_clicks} advance clicks.")
-                            else:
-                                rewind_clicks = 0
-                                while expected_next_part not in downloaded_parts and rewind_clicks < MAX_REWIND_CLICKS:
-                                    try:
-                                        rewind_btn = player_frame.locator('button[aria-label*="Rewind 15 seconds"]')
-                                        rewind_btn.first.click(timeout=3000)
-                                        rewind_clicks += 1
-                                        print(f"  Rewind 15s {rewind_clicks}/{MAX_REWIND_CLICKS} (looking for part {expected_next_part})")
-                                        time.sleep(REWIND_WAIT_SEC)
-                                    except (PlaywrightTimeoutError, Exception) as e:
-                                        print(f"  Rewind click failed: {e}")
-                                        break
-                                status = "found" if expected_next_part in downloaded_parts else "not found"
-                                print(f"  Part {expected_next_part} {status} after {rewind_clicks} rewind clicks (prev-chapter unavailable).")
+                            print(f"  Part {expected_next_part} not found after {prev_chapter_clicks} prev-chapter + {total_advance_clicks} advances.")
 
                 if len(downloaded_parts) == current_parts_count:
                     no_new_parts_count += 1

--- a/libby_download.py
+++ b/libby_download.py
@@ -22,6 +22,23 @@ active_downloads_count = 0
 _latest_libby_part_number_trigger = None # Global variable to store the last part number seen in a Libby URL
 _libby_url_template = None # Captured from first part trigger, used to construct URLs for missing parts
 _signed_spine_urls = {} # spine_index -> full signed Libby URL, captured from openbook data
+_last_seen_part = 0 # Most recent part number triggered by Libby, in or out of order (used for gap detection)
+# The request handler ignores everything until this is True. It's flipped on only once
+# we've reached the rewind step, so the player's initial auto-load (its resume position
+# plus manifest requests, whose part numbers can mismatch the audio actually served)
+# can't mis-pair a wrong-part CDN download onto Part 1.
+downloads_enabled = False
+
+
+def next_expected_part():
+    """The next part we should accept: the smallest part number (from 1) not yet recorded.
+
+    Parts are only recorded in strict ascending order, so this is always one past the
+    contiguous run we've collected so far."""
+    expected = 1
+    while expected in found_parts:
+        expected += 1
+    return expected
 
 # --- Configuration Management Functions ---
 def load_config():
@@ -80,7 +97,14 @@ def handle_request(request):
     Callback function to process intercepted network requests.
     Identifies and downloads audiobook MP3 parts directly using requests library.
     """
-    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger, _libby_url_template
+    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger, _libby_url_template, _last_seen_part
+
+    # Ignore all traffic until we've reached the rewind step. During the player's initial
+    # auto-load, Libby fires manifest/resume requests whose part numbers don't reliably
+    # match the audio it actually streams, which would mis-pair a CDN download onto the
+    # wrong part (e.g. saving Part 5's audio as Part_01.mp3).
+    if not downloads_enabled:
+        return
 
     # Case 1: Intercept initial Libby part request (contains PartXX.mp3)
     # This request triggers the playback and sets up the session for the CDN download.
@@ -89,16 +113,29 @@ def handle_request(request):
         if part_match:
             part_number = int(part_match.group(1))
             with active_downloads_lock:
-                _latest_libby_part_number_trigger = part_number
-                found_parts.add(part_number)
+                # Always note the most recent triggered part (for gap detection) and
+                # cache its signed URL / URL template regardless of order.
+                _last_seen_part = part_number
                 if _libby_url_template is None:
                     _libby_url_template = re.sub(r'Part\d+\.mp3\?cmpt=.*', '', request.url)
                     print(f"Captured Libby URL template: {_libby_url_template}")
                 _signed_spine_urls[part_number] = request.url
-            print(f"Detected Libby part trigger: {request.url} -> Set _latest_libby_part_number_trigger to {part_number}")
+
+                # Only accept parts in strict ascending order. This means the player's
+                # resume-position jump (e.g. starting mid-book at Part 6) and chapter
+                # overshoots are NOT recorded, so they'll be captured "fresh" once we
+                # actually reach them in sequence.
+                expected = next_expected_part()
+                accepted = (part_number == expected)
+                if accepted:
+                    found_parts.add(part_number)
+                    _latest_libby_part_number_trigger = part_number
+            if accepted:
+                print(f"Detected in-order part trigger: Part {part_number} (accepted for download).")
+            else:
+                print(f"Ignoring out-of-order Part {part_number} trigger (expected Part {expected}); will capture it when reached in order.")
             # Do NOT attempt to get response body here, as it's typically empty or a redirect trigger.
             # We are just capturing the part number for the subsequent CDN request.
-            breakpoint()
             return # Exit early, this request is just a trigger
 
     # Case 2: Intercept actual CDN audio request (does NOT contain PartXX.mp3, relies on previous trigger)
@@ -134,16 +171,47 @@ def handle_request(request):
         file_name = f"Part_{part_number:02d}.mp3"
         file_path = os.path.join(config['DOWNLOAD_DIRECTORY'], file_name)
 
+        # Fast skip: if we already have this part on disk and it's the same size as
+        # the remote part, don't re-download it (saves lots of time on reruns/debugging).
+        # Probe the remote size cheaply with a 1-byte range request and read the total
+        # from the Content-Range header instead of pulling the whole ~35 MB body.
+        if os.path.exists(file_path):
+            local_size = os.path.getsize(file_path)
+            remote_size = None
+            try:
+                probe_headers = {k: v for k, v in request.headers.items() if k.lower() != "range"}
+                probe_headers["Range"] = "bytes=0-0"
+                probe = requests.get(cdn_audio_url, headers=probe_headers, timeout=30)
+                content_range = probe.headers.get("content-range", "")
+                if "/" in content_range:
+                    remote_size = int(content_range.rsplit("/", 1)[-1])
+                elif probe.headers.get("content-length"):
+                    remote_size = int(probe.headers["content-length"])
+            except Exception as e:
+                print(f"  Size probe for Part {part_number} failed ({e}); will download normally.")
+            if remote_size is not None and local_size == remote_size:
+                print(f"Skipping Part {part_number}: already on disk with matching size ({local_size} bytes).")
+                with active_downloads_lock:
+                    downloaded_parts.add(part_number)
+                    max_part_number_found = max(max_part_number_found, part_number)
+                    _latest_libby_part_number_trigger = None
+                return
+
         with active_downloads_lock:
             active_downloads_count += 1
         print(f"  Incremented active_downloads_count to: {active_downloads_count}")
 
         try:
             print(f"  Making direct requests.get() call for Part {part_number} to {cdn_audio_url}...")
-            # Use requests.get() to download the content directly
-            # Add headers from the original request to ensure session/auth is carried over if needed
+            # Use requests.get() to download the content directly.
+            # Copy the original request headers (to carry over session/auth) but force a
+            # full download: the browser's audio player often sends a Range header when it
+            # seeks/re-buffers, which would make the CDN return a partial (206) fragment.
+            # Requesting "bytes=0-" guarantees we always get the complete part from byte 0.
+            download_headers = {k: v for k, v in request.headers.items() if k.lower() != "range"}
+            download_headers["Range"] = "bytes=0-"
             # Set a timeout for the requests call to prevent indefinite hangs
-            download_response = requests.get(cdn_audio_url, headers=request.headers, timeout=60) # 60 seconds timeout
+            download_response = requests.get(cdn_audio_url, headers=download_headers, timeout=60) # 60 seconds timeout
 
             content_length = len(download_response.content)
             print(f"  Requests.get() Response Body Size: {content_length} bytes for Part {part_number}")
@@ -360,19 +428,26 @@ def run():
                 # Get all library choice buttons
                 library_choice_buttons = page.locator('.auth-ils-list button').all()
                 options_text = []
+                option_buttons = []
                 for i, button in enumerate(library_choice_buttons):
-                    # Extract text, stripping whitespace and filtering out empty strings
-                    text = button.text_content().strip()
+                    # inner_text() keeps line breaks between child elements (e.g. the
+                    # option name and a "Recommended choice." badge); join them visibly.
+                    text = button.inner_text().strip()
                     if text: # Only add non-empty text
+                        text = ' — '.join(line.strip() for line in text.splitlines() if line.strip())
                         options_text.append(text)
+                        option_buttons.append(button)
 
                 if not options_text:
                     print("No library card usage options found on the page.")
                     return
 
-                # If the option index is not in config or invalid, prompt the user
+                # If the option index is not in config or invalid, list the options and prompt the user
                 if 'LIBRARY_CARD_USAGE_OPTION_INDEX' not in config or \
                    not (0 <= config['LIBRARY_CARD_USAGE_OPTION_INDEX'] < len(options_text)):
+                    print("Where do you use your library card?")
+                    for i, option in enumerate(options_text):
+                        print(f"{i+1}. {option}")
                     while True:
                         try:
                             choice = input("Enter the number of your choice: ")
@@ -389,18 +464,19 @@ def run():
                     print(f"Using saved library card usage option: {options_text[config['LIBRARY_CARD_USAGE_OPTION_INDEX']]}")
 
                 # Click the corresponding button based on the stored/selected index
-                selected_option_text = options_text[config['LIBRARY_CARD_USAGE_OPTION_INDEX']]
-                # Using triple double quotes for robustness in f-string
-                page.click(f"""button:has-text("{selected_option_text}") >> nth={config['LIBRARY_CARD_USAGE_OPTION_INDEX']}""")
-                page.wait_for_load_state('networkidle')
+                option_buttons[config['LIBRARY_CARD_USAGE_OPTION_INDEX']].click(timeout=10000)
+                try:
+                    page.wait_for_load_state('networkidle', timeout=15000)
+                except PlaywrightTimeoutError:
+                    print("Note: network did not go idle after selecting card usage option; continuing anyway.")
                 time.sleep(3)
                 # Fix: Separated f-string for filename from os.path.join
                 filename = f"07_after_select_card_usage_{config['LIBRARY_CARD_USAGE_OPTION_INDEX']+1}.png"
                 screenshot_path = os.path.join(config['DOWNLOAD_DIRECTORY'], filename)
                 page.screenshot(path=screenshot_path)
 
-            except PlaywrightTimeoutError:
-                print("Error: Library card usage options did not appear in time.")
+            except PlaywrightTimeoutError as e:
+                print(f"Error: timed out during library card usage option step: {e}")
                 return
             except Exception as e:
                 print(f"An error occurred while handling library card usage options: {e}")
@@ -540,11 +616,11 @@ def run():
                 for i, title in enumerate(audiobook_titles):
                     print(f"{i+1}. {title}")
 
-                # Select audiobook (auto or manual based on configuration)
-                if AUTO_SELECT_FIRST_AUDIOBOOK:
+                # Select audiobook (auto-select only when there's a single option)
+                if AUTO_SELECT_FIRST_AUDIOBOOK and len(audiobook_titles) == 1:
                     choice_index = 0
                     selected_title = audiobook_titles[choice_index]
-                    print(f"Auto-selected first audiobook: '{selected_title}'")
+                    print(f"Auto-selected the only audiobook on the shelf: '{selected_title}'")
                 else:
                     # Loop until a valid choice is made
                     selected_title = None
@@ -598,12 +674,50 @@ def run():
             screenshot_path = os.path.join(config['DOWNLOAD_DIRECTORY'], "16_after_audiobook_detail_load.png")
             page.screenshot(path=screenshot_path)
 
-            # Navigate to the beginning of the book so the forward pass starts from Part 1
+            # Navigate to the beginning of the book so the forward pass starts from Part 1.
+            # Recording is gated to strict ascending order (see handle_request), so the
+            # resume position that loaded above was ignored; Part 1 will be the first part
+            # accepted once the rewind navigation triggers it.
+            global downloads_enabled
             try:
                 player_frame_init = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
-                for rewind_i in range(50):
+                prev_btn = player_frame_init.locator('button[aria-label*="Previous Chapter"]')
+                # Wait for the player to be ready before rewinding, keyed on the Next Chapter
+                # button. That button is present throughout the book, whereas Previous Chapter
+                # is hidden at the very start - so waiting on Previous Chapter would stall for
+                # the full timeout whenever the book opens at/near the beginning.
+                try:
+                    player_frame_init.locator('button[aria-label*="Next Chapter"]').first.wait_for(state='visible', timeout=60000)
+                except PlaywrightTimeoutError:
+                    print("Warning: player controls did not become visible within 60s; rewind may fail.")
+
+                # The initial auto-load (resume position + manifest traffic) is done. Enable
+                # the handler now so the rewind navigation's Part 1 trigger is the first
+                # thing captured - not the mid-book resume position that loaded above.
+                downloads_enabled = True
+                print("Rewind step reached: request handler enabled, capturing from Part 1 onward.")
+
+                # If Libby shows a "Recent place" history-back button pointing near the
+                # start of the book, click it to jump straight there instead of stepping
+                # back one chapter at a time.
+                try:
+                    back_btn = player_frame_init.locator('button.history-bar-back-button')
+                    if back_btn.count() > 0 and back_btn.first.is_visible():
+                        place_text = back_btn.first.locator('.place-phrase-visual').first.text_content().strip()
+                        total_sec = 0
+                        for segment in place_text.split(':'):
+                            total_sec = total_sec * 60 + int(segment)
+                        if total_sec == 0:
+                            print(f"History-back button offers recent place {place_text}; jumping straight to it.")
+                            back_btn.first.click(timeout=3000)
+                            time.sleep(3)
+                        else:
+                            print(f"History-back button present but points to {place_text}; ignoring it.")
+                except Exception as e:
+                    print(f"History-back shortcut not used: {e}")
+
+                for rewind_i in range(300):
                     try:
-                        prev_btn = player_frame_init.locator('button[aria-label*="Previous Chapter"]')
                         prev_btn.first.click(timeout=2000)
                         time.sleep(0.5)
                     except (PlaywrightTimeoutError, Exception):
@@ -619,277 +733,112 @@ def run():
             MAX_NO_NEW_PARTS_ITERATIONS = 10 # Stop if no new parts found for this many clicks
             MAX_FORWARD_CLICKS = 500 # Safety limit for forward clicks
 
-            # Selector for forward navigation - "Next Chapter" button (aria-label e.g. "Next Chapter . 12 minutes ahead.")
-            # Minutes value varies by chapter, so match only the fixed part of the label.
-            FORWARD_SELECTORS = [
-                'button[aria-label*="Next Chapter"]',  # Next chapter (label varies: "Next Chapter . N minutes ahead.")
-                'button.chapter-bar-next-button',
-                'button[aria-label*="next chapter"]',
-                'button[aria-label*="Advance 15 seconds"]',  # Fallback: 15s skip
-                'button.mini-player-jump-ahead',
-            ]
-
-            MAX_REWIND_CLICKS = 40  # ~10 minutes of rewind (15s per click) to find a missed part
-            REWIND_WAIT_SEC = 3    # Wait after each rewind click for part to load
+            MAX_GAP_SKIP_CLICKS = 200  # ~50 minutes of audio (15s per click) to scan a chapter for a missed part
+            GAP_SKIP_WAIT_SEC = 2      # Wait after each 15s skip for the part trigger to fire
 
             for i in range(MAX_FORWARD_CLICKS):
                 current_parts_count = len(downloaded_parts)
-                expected_next_part = max_part_number_found + 1  # Consecutive part we expect next
+                expected_next_part = next_expected_part()  # Next part we still need, in order
                 print(f"Forward pass iteration {i+1}. Current parts downloaded: {current_parts_count} (expect next part {expected_next_part})")
 
-                # Try to find the "Next Chapter" button (advances to next part; label e.g. "Next Chapter . 12 minutes ahead.")
-                # The Libby player runs in an iframe (listen.libbyapp.com); the button is inside it at index 12.
-                button_found = False
+                # Advance with the "Next Chapter" button only (aria-label match). This has
+                # proven reliable; the old fallback selectors (chapter-bar-next-button,
+                # 15s-skip, JS clicks) were removed because they stay present-but-hidden at
+                # the end of the book and kept the loop "advancing" forever.
+                player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+                next_chapter_btn = player_frame.locator('button[aria-label*="Next Chapter"]')
 
-                # First: target the Libby player iframe and click Next Chapter (aria-label contains "Next Chapter", minutes vary)
+                # Log the button's state every iteration so its behaviour (especially at the
+                # end of the book, where it becomes present-but-hidden) is always visible.
+                nc_count = -1
+                nc_visible = False
+                nc_aria = None
+                nc_bbox = None
                 try:
-                    player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
-                    next_chapter_btn = player_frame.locator('button[aria-label*="Next Chapter"]')
+                    nc_count = next_chapter_btn.count()
+                    if nc_count > 0:
+                        first_btn = next_chapter_btn.first
+                        nc_visible = first_btn.is_visible()
+                        nc_aria = first_btn.get_attribute('aria-label')
+                        nc_bbox = first_btn.bounding_box()
+                except Exception as e:
+                    print(f"  [next-chapter] error reading button metadata: {e}")
+                print(f"  [next-chapter] count={nc_count} visible={nc_visible} aria-label={nc_aria!r} bbox={nc_bbox}")
+
+                # End of book: the Next Chapter button is gone or no longer visible (it stays
+                # in the DOM but hidden on the last chapter). Playback never reaches the true
+                # audio end via chapter skips, so this - not the play button's "The End"
+                # text - is our stop signal.
+                if nc_count == 0 or not nc_visible:
+                    print("End of book detected: 'Next Chapter' button is not present/visible. Stopping forward pass.")
+                    break
+
+                button_found = False
+                try:
                     next_chapter_btn.first.click(timeout=2000)
-                    print("Found forward button in player iframe (Next Chapter)")
+                    print("  Clicked Next Chapter.")
                     button_found = True
                     time.sleep(5)
-                except (PlaywrightTimeoutError, Exception):
-                    pass
+                except (PlaywrightTimeoutError, Exception) as e:
+                    print(f"  Next Chapter click failed despite being visible: {e}")
+                    break # Treat an unclickable button as end of book
 
-                # Fallback: check other iframes with FORWARD_SELECTORS
-                if not button_found:
-                    try:
-                        iframes = page.locator('iframe').all()
-                        for iframe_locator in iframes:
+                # Gap recovery: chapters can span multiple audio parts, so a Next
+                # Chapter jump can skip over the start of a part entirely (e.g. it lands
+                # on Part 6 while Part 5 was never played). Because recording is gated to
+                # ascending order, the skipped part simply never got accepted: the next
+                # expected part is still missing even though we've now seen a higher part.
+                # When that happens, step back chapter-by-chapter until the player is
+                # positioned BEFORE the missing part, then advance in 15s steps; each
+                # skipped part triggers in order and is accepted as we pass through it.
+                if button_found:
+                    time.sleep(2)  # let the part trigger from the chapter jump arrive
+                    landed = _last_seen_part  # highest part the player has reached so far
+                    missing_part = expected_next_part
+                    if landed > missing_part:
+                        print(f"Gap detected: player reached Part {landed} but Part {missing_part} was skipped. Stepping back to before Part {missing_part}...")
+                        player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+                        prev_chapter_btn = player_frame.locator('button[aria-label*="Previous Chapter"]')
+
+                        # Step back one chapter at a time until the player lands on a part
+                        # earlier than the one we're missing (a single chapter back is often
+                        # not enough - the skipped part can start several chapters earlier).
+                        MAX_BACK_CHAPTERS = 15
+                        back_clicks = 0
+                        while back_clicks < MAX_BACK_CHAPTERS:
                             try:
-                                # content_frame is a property (not a method); use .locator().first, not Frame API
-                                iframe_frame = iframe_locator.content_frame
-                                if iframe_frame:
-                                    for selector in FORWARD_SELECTORS:
-                                        try:
-                                            iframe_frame.locator(selector).first.wait_for(state='visible', timeout=2000)
-                                            print(f"Found forward button in iframe with selector: {selector}")
-                                            iframe_frame.locator(selector).first.click()
-                                            button_found = True
-                                            time.sleep(5)
-                                            break
-                                        except PlaywrightTimeoutError:
-                                            continue
-                                        except Exception as e:
-                                            print(f"Error with iframe selector {selector}: {e}")
-                                            continue
-                                    if button_found:
-                                        break
-                            except Exception as e:
-                                print(f"Error accessing iframe: {e}")
-                                continue
-                    except Exception as e:
-                        print(f"Error checking for iframes: {e}")
-
-                # If not found in iframe, try main page
-                if not button_found:
-                    for selector in FORWARD_SELECTORS:
-                        try:
-                            page.wait_for_selector(selector, timeout=2000)
-                            print(f"Found forward button with selector: {selector}")
-                            page.click(selector)
-                            button_found = True
-
-                            if button_found:
-                                time.sleep(5) # Reduced sleep time here
+                                prev_chapter_btn.first.click(timeout=3000)
+                            except (PlaywrightTimeoutError, Exception) as e:
+                                print(f"  Reached start of book while stepping back ({e}).")
                                 break
-                        except PlaywrightTimeoutError:
-                            continue # Try next selector
-                        except Exception as e:
-                            print(f"Error with selector {selector}: {e}")
-                            continue # Try next selector
-                
-                # Last resort: try JavaScript click (works even if button is in iframe)
-                if not button_found:
-                    try:
-                        result = page.evaluate("""
-                            () => {
-                                const btn = document.querySelector('button.mini-player-jump-ahead');
-                                if (btn) {
-                                    btn.click();
-                                    return {success: true, found: true};
-                                }
-                                // Also check in iframes
-                                const iframes = document.querySelectorAll('iframe');
-                                for (let iframe of iframes) {
-                                    try {
-                                        const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-                                        const iframeBtn = iframeDoc.querySelector('button.mini-player-jump-ahead');
-                                        if (iframeBtn) {
-                                            iframeBtn.click();
-                                            return {success: true, found: true, inIframe: true};
-                                        }
-                                    } catch (e) {
-                                        // Cross-origin iframe, can't access
-                                    }
-                                }
-                                return {success: false, found: false};
-                            }
-                        """)
-                        if result.get('success'):
-                            print(f"Successfully clicked forward button via JavaScript (in iframe: {result.get('inIframe', False)})")
-                            button_found = True
-                            time.sleep(5)
-                    except Exception as e:
-                        print(f"JavaScript click attempt failed: {e}")
+                            back_clicks += 1
+                            time.sleep(2)
+                            if _last_seen_part and _last_seen_part < missing_part:
+                                print(f"  Stepped back {back_clicks} chapter(s) to Part {_last_seen_part}; now scanning forward for Part {missing_part}.")
+                                break
+                        else:
+                            print(f"  Stepped back {back_clicks} chapters (cap reached); scanning forward from here.")
 
-                if not button_found:
-                    print("No forward button found with any selector. Debugging...")
-                    # Take screenshot for debugging
-                    debug_screenshot = os.path.join(config['DOWNLOAD_DIRECTORY'], f"debug_no_next_button_{i+1}.png")
-                    page.screenshot(path=debug_screenshot)
-                    print(f"Debug screenshot saved: {debug_screenshot}")
-
-                    # Print all visible buttons on current page for debugging
-                    try:
-                        # Wait a moment for DOM to stabilize
-                        time.sleep(2)
-                        all_buttons = page.locator('button:visible').all()
-                        print(f"Found {len(all_buttons)} visible buttons on current page:")
-                        for idx, button in enumerate(all_buttons):  
+                        skip_btn = player_frame.locator('button[aria-label*="Advance 15 seconds"], button.mini-player-jump-ahead')
+                        skip_clicks = 0
+                        # 15s-skip to fill the parts SKIPPED between expected and the part
+                        # we overshot to (< landed). `landed` sits at a chapter boundary, so
+                        # once the in-between parts are captured we stop and let the normal
+                        # Next Chapter click reach it in the next iteration.
+                        while next_expected_part() < landed and skip_clicks < MAX_GAP_SKIP_CLICKS:
                             try:
-                                text = button.text_content()[:50] if button.text_content() else "No text"
-                                classes = button.get_attribute('class') or "No classes"
-                                aria_label = button.get_attribute('aria-label') or "No aria-label"
-                                # Check if button is actually in viewport
-                                is_visible = button.is_visible()
-                                bounding_box = button.bounding_box()
-                                print(f"  Button {idx}: text='{text}' class='{classes}' aria-label='{aria_label}' visible={is_visible} bbox={bounding_box}")
-                            except Exception as e:
-                                print(f"  Button {idx}: Could not read properties - {e}")
-                        
-                        # Also check for buttons with the specific selectors we're looking for
-                        print("\n=== DETAILED ANALYSIS OF FORWARD BUTTONS ===")
-                        for selector in FORWARD_SELECTORS:
-                            try:
-                                matching_buttons = page.locator(selector).all()
-                                print(f"\nSelector '{selector}': {len(matching_buttons)} total buttons found")
-                                
-                                for idx, btn in enumerate(matching_buttons):
-                                    try:
-                                        # Get basic info
-                                        text = btn.text_content()[:50] if btn.text_content() else "No text"
-                                        classes = btn.get_attribute('class') or "No classes"
-                                        aria_label = btn.get_attribute('aria-label') or "No aria-label"
-                                        
-                                        # Check visibility details
-                                        is_visible = btn.is_visible()
-                                        bounding_box = btn.bounding_box()
-                                        
-                                        # Get computed styles to understand why it might not be visible
-                                        computed_styles = page.evaluate("""
-                                            ([selector, index]) => {
-                                                const buttons = document.querySelectorAll(selector);
-                                                if (buttons[index]) {
-                                                    const btn = buttons[index];
-                                                    const styles = window.getComputedStyle(btn);
-                                                    return {
-                                                        display: styles.display,
-                                                        visibility: styles.visibility,
-                                                        opacity: styles.opacity,
-                                                        pointerEvents: styles.pointerEvents,
-                                                        zIndex: styles.zIndex,
-                                                        position: styles.position,
-                                                        width: styles.width,
-                                                        height: styles.height,
-                                                        offsetParent: btn.offsetParent !== null,
-                                                        clientWidth: btn.clientWidth,
-                                                        clientHeight: btn.clientHeight,
-                                                        offsetWidth: btn.offsetWidth,
-                                                        offsetHeight: btn.offsetHeight
-                                                    };
-                                                }
-                                                return null;
-                                            }
-                                        """, [selector, idx])
-                                        
-                                        print(f"  Button {idx}:")
-                                        print(f"    text='{text}'")
-                                        print(f"    class='{classes}'")
-                                        print(f"    aria-label='{aria_label}'")
-                                        print(f"    is_visible()={is_visible}")
-                                        print(f"    bounding_box={bounding_box}")
-                                        if computed_styles:
-                                            print(f"    CSS display={computed_styles['display']}")
-                                            print(f"    CSS visibility={computed_styles['visibility']}")
-                                            print(f"    CSS opacity={computed_styles['opacity']}")
-                                            print(f"    offsetParent exists={computed_styles['offsetParent']}")
-                                            print(f"    dimensions: {computed_styles['width']} x {computed_styles['height']}")
-                                            print(f"    actual size: {computed_styles['clientWidth']} x {computed_styles['clientHeight']}")
-                                        
-                                        # Check if it's in an iframe
-                                        try:
-                                            frame = btn.content_frame
-                                            if frame:
-                                                print(f"    ⚠️  BUTTON IS IN AN IFRAME!")
-                                        except:
-                                            pass
-                                        
-                                    except Exception as e:
-                                        print(f"  Button {idx}: Error getting details - {e}")
-                                        
-                            except Exception as e:
-                                print(f"  Selector '{selector}': Error - {e}")
-                        
-                        # Check for iframes on the page
-                        print("\n=== CHECKING FOR IFRAMES ===")
-                        try:
-                            iframes = page.locator('iframe').all()
-                            print(f"Found {len(iframes)} iframes on the page")
-                            for idx, iframe_locator in enumerate(iframes):
-                                try:
-                                    src = iframe_locator.get_attribute('src') or "No src"
-                                    print(f"  Iframe {idx}: src='{src[:100]}'")
-                                    # Try to find buttons inside iframe
-                                    try:
-                                        iframe_frame = iframe_locator.content_frame
-                                        if iframe_frame:
-                                            print(f"    Successfully accessed iframe frame object!")
-                                            iframe_buttons = iframe_frame.locator('button.mini-player-jump-ahead').all()
-                                            print(f"    Found {len(iframe_buttons)} skip buttons inside this iframe!")
-                                            # Also check all forward selectors in iframe
-                                            for sel in FORWARD_SELECTORS:
-                                                iframe_sel_buttons = iframe_frame.locator(sel).all()
-                                                if iframe_sel_buttons:
-                                                    visible_in_iframe = [b for b in iframe_sel_buttons if b.is_visible()]
-                                                    print(f"    Found {len(iframe_sel_buttons)} buttons ({len(visible_in_iframe)} visible) with selector '{sel}' in iframe!")
-                                    except Exception as e:
-                                        print(f"    Error accessing iframe content: {e}")
-                                        import traceback
-                                        traceback.print_exc()
-                                except:
-                                    pass
-                        except Exception as e:
-                            print(f"Error checking iframes: {e}")
-                        
-                        # Try force-clicking the button via JavaScript (even if Playwright thinks it's not visible)
-                        print("\n=== ATTEMPTING FORCE CLICK VIA JAVASCRIPT ===")
-                        try:
-                            result = page.evaluate("""
-                                () => {
-                                    const btn = document.querySelector('button.mini-player-jump-ahead');
-                                    if (btn) {
-                                        // Try to click it
-                                        btn.click();
-                                        return {success: true, found: true};
-                                    }
-                                    return {success: false, found: false};
-                                }
-                            """)
-                            print(f"JavaScript click attempt: {result}")
-                        except Exception as e:
-                            print(f"Error with JavaScript click: {e}")
-                    except Exception as e:
-                        print(f"Error listing buttons: {e}")
-                        import traceback
-                        traceback.print_exc()
-
-                    break # Exit loop if button is not found (likely end of book)
-
-                # Note: chapters span multiple audio parts, so chapter navigation
-                # will skip parts that fall mid-chapter. These are handled in Step 4
-                # using direct spine navigation instead of the slow button-click approach.
+                                skip_btn.first.click(timeout=3000)
+                            except (PlaywrightTimeoutError, Exception) as e:
+                                print(f"  15s advance failed during gap recovery: {e}")
+                                break
+                            skip_clicks += 1
+                            time.sleep(GAP_SKIP_WAIT_SEC)
+                            if skip_clicks % 20 == 0:
+                                print(f"  Gap recovery: {skip_clicks} skips so far, next still-missing part is {next_expected_part()} (filling up to {landed - 1})")
+                        if next_expected_part() < landed:
+                            print(f"  Gap recovery gave up after {skip_clicks} skips; Part {next_expected_part()} still missing (Step 4 will retry).")
+                        else:
+                            print(f"  Gap recovery done after {skip_clicks} 15s skips; parts up to {landed - 1} captured. Resuming chapter skips to reach Part {landed}.")
 
                 if len(downloaded_parts) == current_parts_count:
                     no_new_parts_count += 1

--- a/libby_download.py
+++ b/libby_download.py
@@ -21,6 +21,7 @@ active_downloads_lock = threading.Lock()
 active_downloads_count = 0
 _latest_libby_part_number_trigger = None # Global variable to store the last part number seen in a Libby URL
 _libby_url_template = None # Captured from first part trigger, used to construct URLs for missing parts
+_signed_spine_urls = {} # spine_index -> full signed Libby URL, captured from openbook data
 
 # --- Configuration Management Functions ---
 def load_config():
@@ -93,6 +94,7 @@ def handle_request(request):
                 if _libby_url_template is None:
                     _libby_url_template = re.sub(r'Part\d+\.mp3\?cmpt=.*', '', request.url)
                     print(f"Captured Libby URL template: {_libby_url_template}")
+                _signed_spine_urls[part_number] = request.url
             print(f"Detected Libby part trigger: {request.url} -> Set _latest_libby_part_number_trigger to {part_number}")
             # Do NOT attempt to get response body here, as it's typically empty or a redirect trigger.
             # We are just capturing the part number for the subsequent CDN request.
@@ -898,7 +900,7 @@ def run():
                 print(f"Still {current_active} downloads active. Waiting...")
                 time.sleep(5) # Wait a bit before checking again
 
-            # --- Step 4: Retrieve Missing Parts via Direct Spine Navigation ---
+            # --- Step 4: Retrieve Missing Parts via Signed URL Extraction ---
             print("Checking for any missing parts and attempting to retrieve them...")
             missing_parts = []
             for i in range(1, max_part_number_found + 1):
@@ -916,83 +918,80 @@ def run():
                         player_frame_obj = frame
                         break
 
+                # Try to extract all signed spine URLs from the player's JavaScript
+                if player_frame_obj and len(_signed_spine_urls) < max_part_number_found:
+                    print("Extracting signed spine URLs from player...")
+                    try:
+                        spine_data = player_frame_obj.evaluate(r"""
+                            () => {
+                                try {
+                                    var results = {};
+                                    var scripts = document.querySelectorAll('script');
+                                    for (var s of scripts) {
+                                        var text = s.textContent || '';
+                                        var matches = text.matchAll(/Part(\d+)\.mp3\?cmpt=([A-Za-z0-9+\/=%]+--[a-f0-9]+)/g);
+                                        for (var m of matches) {
+                                            results[parseInt(m[1])] = m[2];
+                                        }
+                                    }
+                                    function searchObj(obj, depth) {
+                                        if (depth > 3 || !obj) return;
+                                        try {
+                                            if (typeof obj === 'string' && obj.includes('cmpt=') && obj.includes('Part')) {
+                                                var m = obj.match(/Part(\d+)\.mp3\?cmpt=([A-Za-z0-9+\/=%]+--[a-f0-9]+)/);
+                                                if (m) results[parseInt(m[1])] = m[2];
+                                            }
+                                            if (typeof obj === 'object') {
+                                                for (var k in obj) {
+                                                    try { searchObj(obj[k], depth + 1); } catch(e) {}
+                                                }
+                                            }
+                                        } catch(e) {}
+                                    }
+                                    try { searchObj(window.__NEXT_DATA__, 0); } catch(e) {}
+                                    try { searchObj(window.__STATE__, 0); } catch(e) {}
+                                    try { searchObj(window.roster, 0); } catch(e) {}
+                                    return {found: Object.keys(results).length, urls: results};
+                                } catch(e) {
+                                    return {error: e.message, found: 0, urls: {}};
+                                }
+                            }
+                        """)
+                        print(f"  Spine URL extraction: found {spine_data.get('found', 0)} signed URLs")
+                        if spine_data.get('urls'):
+                            for part_str, cmpt in spine_data['urls'].items():
+                                part_num = int(part_str)
+                                if part_num not in _signed_spine_urls and _libby_url_template:
+                                    full_url = f"{_libby_url_template}Part{part_num:02d}.mp3?cmpt={cmpt}"
+                                    _signed_spine_urls[part_num] = full_url
+                    except Exception as e:
+                        print(f"  Spine URL extraction failed: {e}")
+
                 for missing_part in sorted(missing_parts):
                     if missing_part in downloaded_parts:
                         continue
                     print(f"Attempting to retrieve missing Part {missing_part} (spine {missing_part - 1})...")
 
-                    navigated = False
-                    if player_frame_obj:
-                        try:
-                            result = player_frame_obj.evaluate("""
-                                (spineIndex) => {
-                                    try {
-                                        // OverDrive reader: try common API patterns
-                                        if (typeof bif !== 'undefined' && bif.player) {
-                                            bif.player.openSpine(spineIndex);
-                                            return {success: true, method: 'bif.player.openSpine'};
-                                        }
-                                        // Try window.player
-                                        if (window.player && window.player.openSpine) {
-                                            window.player.openSpine(spineIndex);
-                                            return {success: true, method: 'window.player.openSpine'};
-                                        }
-                                        // Try _roState / redux store
-                                        if (window.__NEXT_DATA__ || window.__store__) {
-                                            return {success: false, method: 'store found but no navigate'};
-                                        }
-                                        // Enumerate global objects that might be the player
-                                        var playerKeys = [];
-                                        for (var key in window) {
-                                            try {
-                                                if (window[key] && typeof window[key] === 'object' &&
-                                                    (window[key].openSpine || window[key].goToSpine ||
-                                                     window[key].loadSpine || window[key].playSpine)) {
-                                                    playerKeys.push(key);
-                                                }
-                                            } catch(e) {}
-                                        }
-                                        if (playerKeys.length > 0) {
-                                            return {success: false, method: 'found objects: ' + playerKeys.join(',')};
-                                        }
-                                        return {success: false, method: 'no player API found'};
-                                    } catch(e) {
-                                        return {success: false, error: e.message};
-                                    }
-                                }
-                            """, missing_part - 1)
-                            print(f"  JS spine navigation result: {result}")
-                            if result.get('success'):
-                                navigated = True
-                                time.sleep(5)
-                        except Exception as e:
-                            print(f"  JS spine navigation failed: {e}")
-
-                    if not navigated and _libby_url_template:
-                        import base64 as b64
-                        spine_json = json.dumps({"spine": missing_part - 1})
-                        cmpt_unsigned = b64.b64encode(spine_json.encode()).decode()
-                        part_url = f"{_libby_url_template}Part{missing_part:02d}.mp3?cmpt={cmpt_unsigned}"
-                        print(f"  Trying direct URL fetch for Part {missing_part}...")
+                    # Method 1: Use stored signed URL if available
+                    if missing_part in _signed_spine_urls and missing_part not in downloaded_parts:
+                        signed_url = _signed_spine_urls[missing_part]
+                        print(f"  Using signed URL for Part {missing_part}...")
                         try:
                             if player_frame_obj:
-                                player_frame_obj.evaluate(f"""
-                                    (url) => {{
+                                player_frame_obj.evaluate("""
+                                    (url) => {
                                         var audio = new Audio();
                                         audio.src = url;
                                         audio.load();
-                                    }}
-                                """, part_url)
-                                time.sleep(5)
-                            page.evaluate(f"""
-                                (url) => fetch(url, {{mode: 'no-cors'}}).catch(() => {{}})
-                            """, part_url)
-                            time.sleep(5)
+                                    }
+                                """, signed_url)
+                                time.sleep(8)
                         except Exception as e:
-                            print(f"  Direct URL fetch failed: {e}")
+                            print(f"  Signed URL fetch failed: {e}")
 
+                    # Method 2: Chapter navigation fallback
                     if missing_part not in downloaded_parts:
-                        print(f"  Trying chapter navigation fallback for Part {missing_part}...")
+                        print(f"  Trying chapter navigation for Part {missing_part}...")
                         player_fl = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
                         PREV_SELS = ['button[aria-label*="Previous Chapter"]', 'button[aria-label*="Previous chapter"]']
                         for attempt in range(3):

--- a/libby_download.py
+++ b/libby_download.py
@@ -46,7 +46,7 @@ def load_config():
             elif field == 'LIBBY_PASSWORD':
                 config[field] = input(f"Please enter your {field.replace('_', ' ')} (PIN): ")
             elif field == 'LIBRARY':
-                config[field] = input(f"Please enter your {field.replace('_', ' ')} (e.g., Boston Public Library): ")
+                config[field] = input(f"Please enter your {field.replace('_', ' ')} (e.g., [REDACTED]): ")
             elif field == 'DOWNLOAD_DIRECTORY':
                 default_dir = os.path.join(os.getcwd(), "Libby_Audiobook_Downloads")
                 config[field] = input(f"Enter download directory (default: {default_dir}): ") or default_dir
@@ -64,6 +64,13 @@ def save_config(config_data):
     with open(CONFIG_FILE, 'w') as f:
         json.dump(config_data, f, indent=4)
     print(f"Saved configuration to {CONFIG_FILE}.")
+
+def sanitize_filename(name):
+    """Remove or replace characters that are invalid in directory/file names."""
+    sanitized = re.sub(r'[<>:"/\\|?*]', '_', name)
+    sanitized = sanitized.strip().strip('.')
+    sanitized = re.sub(r'[_\s]+', ' ', sanitized)
+    return sanitized.strip()
 
 # --- Network Request Handler ---
 def handle_request(request):
@@ -186,7 +193,7 @@ def run():
     config = load_config()
 
     # Playwright Browser Settings - now uses HEADLESS_MODE from config
-    HEADLESS_MODE = False # Keep this as False for debugging, can be moved to config later if desired
+    HEADLESS_MODE = True # Keep this as False for debugging, can be moved to config later if desired
 
     # Initialize Playwright with the stealth plugin
     with Stealth().use_sync(sync_playwright()) as p:
@@ -495,14 +502,28 @@ def run():
 
                 audiobook_tiles = page.locator('.title-list-tiles .title-tile').all()
                 audiobook_titles = []
+                audiobook_authors = []
                 for i, tile in enumerate(audiobook_tiles):
-                    # Extract the title text from within the tile
                     title_element = tile.locator('.title-tile-title').first
                     if title_element:
                         title_text = title_element.text_content().strip().replace('&nbsp;', ' ')
                         audiobook_titles.append(title_text)
 
+                    author_text = ""
+                    for author_selector in ['.title-tile-author', '.title-tile-creator', '.title-tile-subtitle']:
+                        try:
+                            author_element = tile.locator(author_selector).first
+                            if author_element and author_element.is_visible():
+                                candidate = author_element.text_content().strip().replace('&nbsp;', ' ')
+                                if candidate:
+                                    author_text = candidate
+                                    break
+                        except Exception:
+                            continue
+                    audiobook_authors.append(author_text)
+
                 print(f"DEBUG: Parsed Audiobook Titles: {audiobook_titles}")
+                print(f"DEBUG: Parsed Audiobook Authors: {audiobook_authors}")
 
                 if not audiobook_titles:
                     print("No audiobooks found on your shelf.")
@@ -532,6 +553,21 @@ def run():
                                 print("Invalid choice. Please enter a number from the list.")
                         except ValueError:
                             print("Invalid input. Please enter a number.")
+
+                # Create a book-specific download subdirectory (Author/Title or just Title)
+                selected_author = audiobook_authors[choice_index] if choice_index < len(audiobook_authors) else ""
+                book_folder_name = sanitize_filename(selected_title)
+                if selected_author:
+                    author_folder_name = sanitize_filename(selected_author)
+                    book_download_dir = os.path.join(config['DOWNLOAD_DIRECTORY'], author_folder_name, book_folder_name)
+                    print(f"Author: '{selected_author}' -> folder: '{author_folder_name}'")
+                else:
+                    book_download_dir = os.path.join(config['DOWNLOAD_DIRECTORY'], book_folder_name)
+                    print("No author info found on shelf tile; using title-only folder.")
+
+                os.makedirs(book_download_dir, exist_ok=True)
+                print(f"Download directory for this book: {book_download_dir}")
+                config['DOWNLOAD_DIRECTORY'] = book_download_dir
 
                 # Locate the specific audiobook tile using the selected title
                 audiobook_tile_locator = page.locator(f"""div.title-tile:has-text("{selected_title}")""").first
@@ -833,28 +869,72 @@ def run():
 
                 # If we clicked Next Chapter, ensure we didn't skip a part (audio parts can be shorter than chapters)
                 if button_found:
-                    # Short wait for Libby trigger to be seen (found_parts updates immediately in request handler)
                     time.sleep(2)
                     max_found = max(found_parts) if found_parts else 0
                     if expected_next_part not in found_parts and max_found >= expected_next_part:
-                        print(f"Gap detected: expected part {expected_next_part} but have part(s) up to {max_found}. Rewinding to find part {expected_next_part}...")
-                        rewind_clicks = 0
-                        breakpoint()
-                        while expected_next_part not in downloaded_parts: # and rewind_clicks < MAX_REWIND_CLICKS:
-                            try:
-                                player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
-                                rewind_btn = player_frame.locator('button[aria-label*="Rewind 15 seconds"]')
-                                rewind_btn.first.click(timeout=2000)
-                                rewind_clicks += 1
-                                print(f"  Rewind {rewind_clicks}/{MAX_REWIND_CLICKS} (Rewind 15 seconds)")
-                                time.sleep(REWIND_WAIT_SEC)
-                            except (PlaywrightTimeoutError, Exception) as e:
-                                print(f"  Rewind click failed: {e}")
+                        print(f"Gap detected: expected part {expected_next_part} but have part(s) up to {max_found}. Going back to find part {expected_next_part}...")
+                        player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+
+                        PREV_CHAPTER_SELECTORS = [
+                            'button[aria-label*="Previous Chapter"]',
+                            'button[aria-label*="Previous chapter"]',
+                            'button[aria-label*="previous chapter"]',
+                            'button.chapter-bar-prev-button',
+                        ]
+
+                        # Step 1: Jump back using "Previous Chapter" (much faster than 15s rewinds)
+                        prev_chapter_clicks = 0
+                        max_prev_chapters = 5
+                        while expected_next_part not in found_parts and prev_chapter_clicks < max_prev_chapters:
+                            clicked_prev = False
+                            for sel in PREV_CHAPTER_SELECTORS:
+                                try:
+                                    prev_btn = player_frame.locator(sel)
+                                    prev_btn.first.click(timeout=3000)
+                                    clicked_prev = True
+                                    prev_chapter_clicks += 1
+                                    print(f"  Previous Chapter {prev_chapter_clicks}/{max_prev_chapters} (selector: {sel})")
+                                    time.sleep(5)
+                                    break
+                                except (PlaywrightTimeoutError, Exception):
+                                    continue
+                            if not clicked_prev:
+                                print(f"  Could not find Previous Chapter button with any selector.")
                                 break
+
                         if expected_next_part in downloaded_parts:
-                            print(f"  Found part {expected_next_part} after {rewind_clicks} rewind(s).")
+                            print(f"  Found part {expected_next_part} after {prev_chapter_clicks} Previous Chapter click(s).")
                         else:
-                            print(f"  Part {expected_next_part} not found after {MAX_REWIND_CLICKS} rewind clicks.")
+                            # Step 2: If Previous Chapter worked, advance 15s to find exact part boundary.
+                            # If Previous Chapter failed, rewind 15s as fallback.
+                            if prev_chapter_clicks > 0:
+                                advance_clicks = 0
+                                while expected_next_part not in downloaded_parts and advance_clicks < MAX_REWIND_CLICKS:
+                                    try:
+                                        advance_btn = player_frame.locator('button[aria-label*="Advance 15 seconds"]')
+                                        advance_btn.first.click(timeout=3000)
+                                        advance_clicks += 1
+                                        print(f"  Advance 15s {advance_clicks}/{MAX_REWIND_CLICKS} (looking for part {expected_next_part})")
+                                        time.sleep(REWIND_WAIT_SEC)
+                                    except (PlaywrightTimeoutError, Exception) as e:
+                                        print(f"  Advance click failed: {e}")
+                                        break
+                                status = "found" if expected_next_part in downloaded_parts else "not found"
+                                print(f"  Part {expected_next_part} {status} after {prev_chapter_clicks} prev-chapter + {advance_clicks} advance clicks.")
+                            else:
+                                rewind_clicks = 0
+                                while expected_next_part not in downloaded_parts and rewind_clicks < MAX_REWIND_CLICKS:
+                                    try:
+                                        rewind_btn = player_frame.locator('button[aria-label*="Rewind 15 seconds"]')
+                                        rewind_btn.first.click(timeout=3000)
+                                        rewind_clicks += 1
+                                        print(f"  Rewind 15s {rewind_clicks}/{MAX_REWIND_CLICKS} (looking for part {expected_next_part})")
+                                        time.sleep(REWIND_WAIT_SEC)
+                                    except (PlaywrightTimeoutError, Exception) as e:
+                                        print(f"  Rewind click failed: {e}")
+                                        break
+                                status = "found" if expected_next_part in downloaded_parts else "not found"
+                                print(f"  Part {expected_next_part} {status} after {rewind_clicks} rewind clicks (prev-chapter unavailable).")
 
                 if len(downloaded_parts) == current_parts_count:
                     no_new_parts_count += 1
@@ -890,8 +970,12 @@ def run():
                 print("No missing parts detected. All parts downloaded successfully!")
             else:
                 print(f"Missing parts identified: {sorted(missing_parts)}")
-                PREV_CHAPTER_SELECTOR = """button[aria-label*="Previous chapter"]"""
-                # Use player iframe (same as forward pass) so backward seeking actually moves the player
+                PREV_CHAPTER_SELECTORS_STEP4 = [
+                    'button[aria-label*="Previous Chapter"]',
+                    'button[aria-label*="Previous chapter"]',
+                    'button[aria-label*="previous chapter"]',
+                    'button.chapter-bar-prev-button',
+                ]
                 player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
 
                 for missing_part in sorted(missing_parts):
@@ -899,13 +983,19 @@ def run():
                     retries = 3
                     for attempt in range(retries):
                         try:
-                            for _ in range(2): # Click 'previous chapter' a couple of times
-                                try:
-                                    player_frame.locator(PREV_CHAPTER_SELECTOR).first.click(timeout=2000)
-                                    time.sleep(1)
-                                except PlaywrightTimeoutError:
+                            for _ in range(2):
+                                clicked = False
+                                for sel in PREV_CHAPTER_SELECTORS_STEP4:
+                                    try:
+                                        player_frame.locator(sel).first.click(timeout=3000)
+                                        clicked = True
+                                        time.sleep(1)
+                                        break
+                                    except (PlaywrightTimeoutError, Exception):
+                                        continue
+                                if not clicked:
                                     print("Reached beginning of audiobook while seeking backwards.")
-                                    break # Can't go back further
+                                    break
 
                             print(f"Attempt {attempt + 1} to trigger Part {missing_part} download...")
                             time.sleep(5) # Give ample time for network requests

--- a/libby_download.py
+++ b/libby_download.py
@@ -678,7 +678,7 @@ def run():
             # Recording is gated to strict ascending order (see handle_request), so the
             # resume position that loaded above was ignored; Part 1 will be the first part
             # accepted once the rewind navigation triggers it.
-            global downloads_enabled
+            global downloads_enabled, _latest_libby_part_number_trigger
             try:
                 player_frame_init = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
                 prev_btn = player_frame_init.locator('button[aria-label*="Previous Chapter"]')
@@ -839,6 +839,21 @@ def run():
                             print(f"  Gap recovery gave up after {skip_clicks} skips; Part {next_expected_part()} still missing (Step 4 will retry).")
                         else:
                             print(f"  Gap recovery done after {skip_clicks} 15s skips; parts up to {landed - 1} captured. Resuming chapter skips to reach Part {landed}.")
+
+                        # An accepted trigger only marks the part; the browser's CDN audio
+                        # fetch is still in flight. Clicking Next Chapter now can abort that
+                        # fetch ("No Playwright response object"), losing the part until the
+                        # Step 4 retry. Let pending downloads settle before navigating away.
+                        pending = []
+                        wait_deadline = time.time() + 20
+                        while time.time() < wait_deadline:
+                            with active_downloads_lock:
+                                pending = sorted(p for p in found_parts if p not in downloaded_parts)
+                            if not pending:
+                                break
+                            time.sleep(1)
+                        if pending:
+                            print(f"  Warning: recovered part(s) {pending} still not downloaded after 20s; Step 4 will retry them.")
 
                 if len(downloaded_parts) == current_parts_count:
                     no_new_parts_count += 1
@@ -1012,8 +1027,7 @@ def run():
         finally:
             if browser:
                 print("Closing browser...")
-                # browser.close()
-                breakpoint()
+                browser.close()
             print("Script finished.")
 
 # --- How to Run ---

--- a/libby_download.py
+++ b/libby_download.py
@@ -875,6 +875,16 @@ def run():
             else:
                 print(f"Missing parts identified: {sorted(missing_parts)}")
 
+                # These parts' triggers were accepted during the forward pass, but the
+                # audio download never completed. The order gate in handle_request keys
+                # on found_parts, so unless we evict them it would reject every re-trigger
+                # as out-of-order (expecting a part past the end of the book) and the
+                # retries below could never succeed.
+                with active_downloads_lock:
+                    for p in missing_parts:
+                        found_parts.discard(p)
+                    _latest_libby_part_number_trigger = None
+
                 player_frame_obj = None
                 for frame in page.frames:
                     if 'listen.libbyapp.com' in frame.url:

--- a/libby_download.py
+++ b/libby_download.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import time
 import requests
 import json # Import the json library for config file handling
@@ -9,6 +10,39 @@ from playwright_stealth import Stealth # Import the stealth library
 
 # --- Configuration File Path ---
 CONFIG_FILE = 'libby_config.json'
+RUN_LOG_FILE = 'libby_run.log'
+
+
+class _Tee:
+    """Mirror writes to several streams. Used to copy all console output into a
+    log file, because diagnostic lines scroll out of the terminal buffer long
+    before a run finishes."""
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data):
+        for s in self._streams:
+            s.write(data)
+            s.flush()
+
+    def flush(self):
+        for s in self._streams:
+            s.flush()
+
+
+_log_file = None  # Set in __main__; target for log_only()
+
+
+def log_only(msg):
+    """Write a line to the run log file only, skipping the console. For noisy
+    diagnostics (e.g. unmatched-CDN-request spam) that clog the printout but
+    are still useful when digging through a run afterwards."""
+    if _log_file:
+        try:
+            _log_file.write(msg + "\n")
+            _log_file.flush()
+        except Exception:
+            pass
 
 # --- Testing Configuration ---
 AUTO_SELECT_FIRST_AUDIOBOOK = True  # Set to False for manual selection
@@ -23,6 +57,8 @@ _latest_libby_part_number_trigger = None # Global variable to store the last par
 _libby_url_template = None # Captured from first part trigger, used to construct URLs for missing parts
 _signed_spine_urls = {} # spine_index -> full signed Libby URL, captured from openbook data
 _last_seen_part = 0 # Most recent part number triggered by Libby, in or out of order (used for gap detection)
+max_part_number_seen = 0 # Highest part number seen in ANY trigger, even out-of-order/unaccepted ones
+_trigger_seq = 0 # Bumped on every part trigger; lets seek probes wait for a FRESH trigger instead of reading stale state
 # The request handler ignores everything until this is True. It's flipped on only once
 # we've reached the rewind step, so the player's initial auto-load (its resume position
 # plus manifest requests, whose part numbers can mismatch the audio actually served)
@@ -39,6 +75,106 @@ def next_expected_part():
     while expected in found_parts:
         expected += 1
     return expected
+
+
+SNAPSHOT_DIR = 'snapshots'
+
+
+def save_snapshot(page, name):
+    """Save a full-page screenshot plus the page's and player iframe's HTML under
+    snapshots/, so element structure at each screen can be inspected offline."""
+    try:
+        os.makedirs(SNAPSHOT_DIR, exist_ok=True)
+        base = os.path.join(SNAPSHOT_DIR, f"{time.strftime('%Y%m%d-%H%M%S')}_{name}")
+        page.screenshot(path=f"{base}.png", full_page=True)
+        with open(f"{base}.html", 'w') as f:
+            f.write(page.content())
+        for frame in page.frames:
+            if 'listen.libbyapp.com' in frame.url:
+                with open(f"{base}_player_iframe.html", 'w') as f:
+                    f.write(frame.content())
+                break
+        print(f"  [snapshot] saved {base}.(png|html)")
+    except Exception as e:
+        print(f"  [snapshot] failed for {name}: {e}")
+
+
+# The Libby player's scrubber is the "seekometer": a horizontal tape that spans
+# the ENTIRE book, time-linear at 2px per second of audio. Its CSS transform
+# (translate3d(-<px>, 0, 0)) is the playhead position, and dragging the tape
+# left/right seeks. See snapshots/*_player_iframe.html for the captured DOM.
+TAPE_PX_PER_SEC = 2.0
+
+
+def tape_position_px(player_frame):
+    """Current playhead position on the seekometer tape in px, or None."""
+    try:
+        tape = player_frame.locator('.seekometer-tape').first
+        transform = tape.evaluate("el => window.getComputedStyle(el).transform")
+        m = re.search(r'matrix\(([^)]+)\)', transform or '')
+        if not m:
+            return None
+        tx = float(m.group(1).split(',')[4])
+        return -tx
+    except Exception as e:
+        print(f"  [tape-seek] could not read tape position: {e}")
+        return None
+
+
+def seek_tape_to_px(page, player_frame, target_px):
+    """Drag the seekometer tape until the playhead sits at target_px.
+
+    Dragging the tape left advances the playhead. One drag gesture can cover at
+    most ~one viewport width, so this runs closed-loop: read the tape transform,
+    drag up to 80% of the visible tape width, wait for the ease-out transition
+    to settle, re-read, repeat. Returns the final position, or None on failure."""
+    try:
+        clip = player_frame.locator('.seekometer').first
+        box = clip.bounding_box()
+    except Exception:
+        box = None
+    if not box or box['width'] < 50:
+        return None
+    cy = box['y'] + box['height'] / 2
+    cur = None
+    no_move_count = 0
+    for _ in range(60):
+        prev = cur
+        cur = tape_position_px(player_frame)
+        if cur is None:
+            return None
+        delta = target_px - cur
+        # Loose tolerance (~30s of audio): probes are classified by where they
+        # actually landed, so pixel precision buys nothing and chasing it makes
+        # the loop fight the tape's snap/ease animations.
+        if abs(delta) <= 60:
+            return cur
+        if prev is not None and abs(cur - prev) < 1.0:
+            no_move_count += 1
+            if no_move_count >= 3:
+                print(f"  [tape-seek] tape not responding to drags (stuck at {cur:.0f}px, want {target_px:.0f}px).")
+                return None
+        else:
+            no_move_count = 0
+        max_step = box['width'] * 0.8
+        step = max(-max_step, min(max_step, delta))
+        # Start the gesture offset from center so both ends stay inside the tape.
+        sx_start = box['x'] + box['width'] / 2 + step / 2
+        sx_end = sx_start - step
+        try:
+            # Drag slowly and hold still before releasing: a fast flick gives the
+            # tape momentum, so it coasts past the target (firing part triggers
+            # for positions merely passed over) and never settles where asked.
+            page.mouse.move(sx_start, cy)
+            page.mouse.down()
+            page.mouse.move(sx_end, cy, steps=25)
+            time.sleep(0.4)
+            page.mouse.up()
+        except Exception as e:
+            print(f"  [tape-seek] drag gesture failed: {e}")
+            return None
+        time.sleep(0.8)  # tape has a 500ms ease-out transition
+    return cur
 
 # --- Configuration Management Functions ---
 def load_config():
@@ -97,7 +233,7 @@ def handle_request(request):
     Callback function to process intercepted network requests.
     Identifies and downloads audiobook MP3 parts directly using requests library.
     """
-    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger, _libby_url_template, _last_seen_part
+    global downloaded_parts, found_parts, max_part_number_found, active_downloads_count, _latest_libby_part_number_trigger, _libby_url_template, _last_seen_part, max_part_number_seen, _trigger_seq
 
     # Ignore all traffic until we've reached the rewind step. During the player's initial
     # auto-load, Libby fires manifest/resume requests whose part numbers don't reliably
@@ -116,6 +252,8 @@ def handle_request(request):
                 # Always note the most recent triggered part (for gap detection) and
                 # cache its signed URL / URL template regardless of order.
                 _last_seen_part = part_number
+                max_part_number_seen = max(max_part_number_seen, part_number)
+                _trigger_seq += 1
                 if _libby_url_template is None:
                     _libby_url_template = re.sub(r'Part\d+\.mp3\?cmpt=.*', '', request.url)
                     print(f"Captured Libby URL template: {_libby_url_template}")
@@ -141,7 +279,9 @@ def handle_request(request):
     # Case 2: Intercept actual CDN audio request (does NOT contain PartXX.mp3, relies on previous trigger)
     elif "audioclips.cdn.overdrive.com" in request.url:
         if _latest_libby_part_number_trigger is None:
-            print(f"Skipping CDN request {request.url}: No preceding Libby part trigger found. This might be an unrelated CDN asset.")
+            # Log-only: this fires constantly (every re-buffer of an already-handled
+            # part) and would drown out the console output.
+            log_only(f"Skipping CDN request {request.url}: No preceding Libby part trigger found. This might be an unrelated CDN asset.")
             return
 
         part_number = _latest_libby_part_number_trigger
@@ -578,6 +718,7 @@ def run():
 
             # --- Prompt user for audiobook selection on the shelf ---
             print("\nAudiobooks on your Shelf:")
+            save_snapshot(page, "shelf")
             try:
                 # Wait for audiobook tiles to be visible
                 page.wait_for_selector('.title-list-tiles .title-tile', timeout=15000)
@@ -616,8 +757,18 @@ def run():
                 for i, title in enumerate(audiobook_titles):
                     print(f"{i+1}. {title}")
 
+                # Non-interactive preselect by title (for unattended/testing runs):
+                # LIBBY_BOOK_TITLE=Wicked picks the first shelf title containing the
+                # string, case-insensitively. Shelf order is not stable, so piping a
+                # number into stdin can select the wrong book.
+                preselect_title = os.environ.get('LIBBY_BOOK_TITLE', '').strip()
+                preselect_matches = [i for i, t in enumerate(audiobook_titles) if preselect_title and preselect_title.lower() in t.lower()]
+                if preselect_matches:
+                    choice_index = preselect_matches[0]
+                    selected_title = audiobook_titles[choice_index]
+                    print(f"Preselected via LIBBY_BOOK_TITLE={preselect_title!r}: '{selected_title}'")
                 # Select audiobook (auto-select only when there's a single option)
-                if AUTO_SELECT_FIRST_AUDIOBOOK and len(audiobook_titles) == 1:
+                elif AUTO_SELECT_FIRST_AUDIOBOOK and len(audiobook_titles) == 1:
                     choice_index = 0
                     selected_title = audiobook_titles[choice_index]
                     print(f"Auto-selected the only audiobook on the shelf: '{selected_title}'")
@@ -671,6 +822,7 @@ def run():
 
             print("Audiobook player opened. Rewinding to beginning...")
             time.sleep(5)
+            save_snapshot(page, "player_opened")
             screenshot_path = os.path.join(config['DOWNLOAD_DIRECTORY'], "16_after_audiobook_detail_load.png")
             page.screenshot(path=screenshot_path)
 
@@ -733,8 +885,10 @@ def run():
             MAX_NO_NEW_PARTS_ITERATIONS = 10 # Stop if no new parts found for this many clicks
             MAX_FORWARD_CLICKS = 500 # Safety limit for forward clicks
 
-            MAX_GAP_SKIP_CLICKS = 200  # ~50 minutes of audio (15s per click) to scan a chapter for a missed part
-            GAP_SKIP_WAIT_SEC = 2      # Wait after each 15s skip for the part trigger to fire
+            MAX_SEEK_PROBES = 20          # Binary-search probes per missing part (resolution ~1/2^20 of the slider)
+            SEEK_TRIGGER_TIMEOUT_SEC = 12  # Max wait for a fresh part trigger after a seek probe (the player defers loading after rapid scrubs)
+            MAX_GAP_SKIP_CLICKS = 200     # Fallback 15s-skip budget floor when no seek slider is found
+            GAP_SKIP_WAIT_SEC = 2         # Wait after each seek/skip for the part trigger to fire
 
             for i in range(MAX_FORWARD_CLICKS):
                 current_parts_count = len(downloaded_parts)
@@ -771,6 +925,7 @@ def run():
                 # text - is our stop signal.
                 if nc_count == 0 or not nc_visible:
                     print("End of book detected: 'Next Chapter' button is not present/visible. Stopping forward pass.")
+                    save_snapshot(page, "end_of_book")
                     break
 
                 button_found = False
@@ -797,7 +952,12 @@ def run():
                     missing_part = expected_next_part
                     if landed > missing_part:
                         print(f"Gap detected: player reached Part {landed} but Part {missing_part} was skipped. Stepping back to before Part {missing_part}...")
+                        save_snapshot(page, f"gap_recovery_part{missing_part}")
                         player_frame = page.frame_locator('iframe[src*="listen.libbyapp.com"]')
+                        # We're sitting at the overshoot chapter's start right now: the
+                        # missing part's boundary lies BEFORE this tape position. Record it
+                        # as the upper bound for the seek search below.
+                        gap_hi_px = tape_position_px(player_frame)
                         prev_chapter_btn = player_frame.locator('button[aria-label*="Previous Chapter"]')
 
                         # Step back one chapter at a time until the player lands on a part
@@ -819,26 +979,117 @@ def run():
                         else:
                             print(f"  Stepped back {back_clicks} chapters (cap reached); scanning forward from here.")
 
-                        skip_btn = player_frame.locator('button[aria-label*="Advance 15 seconds"], button.mini-player-jump-ahead')
-                        skip_clicks = 0
-                        # 15s-skip to fill the parts SKIPPED between expected and the part
-                        # we overshot to (< landed). `landed` sits at a chapter boundary, so
-                        # once the in-between parts are captured we stop and let the normal
-                        # Next Chapter click reach it in the next iteration.
-                        while next_expected_part() < landed and skip_clicks < MAX_GAP_SKIP_CLICKS:
+                        # Binary-search the seekometer tape for the missing part(s).
+                        # The tape is time-linear over the whole book (2px/sec), so seeking
+                        # to a tape position triggers that position's part request, and
+                        # position -> part number is monotonic: each probe halves the
+                        # interval. The order gate reads out the result: overshoot probes
+                        # are ignored, and the probe that lands inside the target part is
+                        # the expected one, so it's accepted and downloads.
+                        # Search between here (known to be in a part < target after the
+                        # step-back) and the overshoot chapter's start captured above.
+                        lo = tape_position_px(player_frame)
+                        hi = gap_hi_px
+                        if hi is None:
                             try:
-                                skip_btn.first.click(timeout=3000)
-                            except (PlaywrightTimeoutError, Exception) as e:
-                                print(f"  15s advance failed during gap recovery: {e}")
-                                break
-                            skip_clicks += 1
-                            time.sleep(GAP_SKIP_WAIT_SEC)
-                            if skip_clicks % 20 == 0:
-                                print(f"  Gap recovery: {skip_clicks} skips so far, next still-missing part is {next_expected_part()} (filling up to {landed - 1})")
+                                tape_w = player_frame.locator('.seekometer-tape').first.evaluate("el => el.getBoundingClientRect().width")
+                                hi = float(tape_w)
+                            except Exception as e:
+                                print(f"  [tape-seek] could not read tape width ({e})")
+                        seek_ok = lo is not None and hi is not None and hi > lo
+                        if not seek_ok:
+                            print(f"  [seek-search] no usable tape bounds (lo={lo}, hi={hi}); falling back to 15s skips.")
+                        if seek_ok:
+                            while next_expected_part() < landed and seek_ok:
+                                target = next_expected_part()
+                                s_lo, s_hi = lo, hi
+                                probes = 0
+                                while probes < MAX_SEEK_PROBES and next_expected_part() == target:
+                                    if s_hi - s_lo < 30:  # interval down to ~15s of audio; boundary pinned
+                                        print(f"  [seek-search] interval collapsed to {s_hi - s_lo:.0f}px without capturing Part {target}.")
+                                        break
+                                    mid = (s_lo + s_hi) / 2.0
+                                    seq_before = _trigger_seq
+                                    landed_px = seek_tape_to_px(page, player_frame, mid)
+                                    if landed_px is None:
+                                        print("  [seek-search] tape drag failed; falling back to 15s skips.")
+                                        seek_ok = False
+                                        break
+                                    probes += 1
+                                    # Wait for a FRESH trigger from this seek before classifying
+                                    # the probe - a fixed short sleep can read a stale part number
+                                    # and misclassify. Seeks within the already-loaded part fire
+                                    # no new trigger, so on timeout the stale value IS correct.
+                                    probe_deadline = time.time() + SEEK_TRIGGER_TIMEOUT_SEC
+                                    while time.time() < probe_deadline and _trigger_seq == seq_before:
+                                        time.sleep(0.25)
+                                    fresh = _trigger_seq != seq_before
+                                    if fresh:
+                                        # Scrubbing fires triggers for parts merely passed over.
+                                        # Wait for the stream to go quiet (2s) so we read the
+                                        # trigger belonging to the tape's resting position.
+                                        last_seq = _trigger_seq
+                                        quiet_since = time.time()
+                                        settle_deadline = time.time() + 8
+                                        while time.time() < settle_deadline and (time.time() - quiet_since) < 2.0:
+                                            time.sleep(0.25)
+                                            if _trigger_seq != last_seq:
+                                                last_seq = _trigger_seq
+                                                quiet_since = time.time()
+                                    cur = _last_seen_part
+                                    # Classify against where the tape actually SETTLED, not the
+                                    # requested midpoint - drags aren't pixel-accurate and the
+                                    # tape can drift after release; narrowing by the wrong
+                                    # coordinate corrupts the interval.
+                                    settled_px = tape_position_px(player_frame)
+                                    if settled_px is None:
+                                        settled_px = landed_px
+                                    print(f"  [seek-search] probe {probes}/{MAX_SEEK_PROBES}: tape_px={settled_px:.0f} (~{settled_px / TAPE_PX_PER_SEC / 60:.1f} min) -> part {cur} ({'fresh trigger' if fresh else 'no new trigger'}, target {target})")
+                                    if cur < target:
+                                        s_lo = max(s_lo, settled_px)
+                                    elif cur > target:
+                                        s_hi = min(s_hi, settled_px)
+                                if not seek_ok:
+                                    break
+                                if next_expected_part() == target:
+                                    print(f"  Seek search could not trigger Part {target} in {probes} probes; falling back to 15s skips.")
+                                    break
+                                print(f"  Seek search captured Part {target} in {probes} probes.")
+                                lo = tape_position_px(player_frame) or lo  # continue from here for the next missing part
+
+                        # Fallback when no slider was found or the search stalled: play
+                        # through the chapter in 15s steps, budgeted from the chapter length
+                        # in the Next Chapter label ("Next Chapter . 88 minutes ahead.").
                         if next_expected_part() < landed:
-                            print(f"  Gap recovery gave up after {skip_clicks} skips; Part {next_expected_part()} still missing (Step 4 will retry).")
+                            skip_budget = MAX_GAP_SKIP_CLICKS
+                            try:
+                                label = player_frame.locator('button[aria-label*="Next Chapter"]').first.get_attribute('aria-label') or ""
+                                hours_m = re.search(r'(\d+)\s*hour', label)
+                                minutes_m = re.search(r'(\d+)\s*minute', label)
+                                total_min = (int(hours_m.group(1)) * 60 if hours_m else 0) + (int(minutes_m.group(1)) if minutes_m else 0)
+                                if total_min:
+                                    skip_budget = max(skip_budget, (total_min * 60) // 15 + 20)
+                                    print(f"  Chapter ahead is ~{total_min} min of audio; skip budget set to {skip_budget}.")
+                            except Exception as e:
+                                print(f"  Could not read chapter length for skip budget ({e}); using default {skip_budget}.")
+
+                            skip_btn = player_frame.locator('button[aria-label*="Advance 15 seconds"], button.mini-player-jump-ahead')
+                            skip_clicks = 0
+                            while next_expected_part() < landed and skip_clicks < skip_budget:
+                                try:
+                                    skip_btn.first.click(timeout=3000)
+                                except (PlaywrightTimeoutError, Exception) as e:
+                                    print(f"  15s advance failed during gap recovery: {e}")
+                                    break
+                                skip_clicks += 1
+                                time.sleep(GAP_SKIP_WAIT_SEC)
+                                if skip_clicks % 20 == 0:
+                                    print(f"  Gap recovery: {skip_clicks}/{skip_budget} skips so far, next still-missing part is {next_expected_part()} (filling up to {landed - 1})")
+
+                        if next_expected_part() < landed:
+                            print(f"  Gap recovery gave up; Part {next_expected_part()} still missing (Step 4 will retry).")
                         else:
-                            print(f"  Gap recovery done after {skip_clicks} 15s skips; parts up to {landed - 1} captured. Resuming chapter skips to reach Part {landed}.")
+                            print(f"  Gap recovery done; parts up to {landed - 1} captured. Resuming chapter skips to reach Part {landed}.")
 
                         # An accepted trigger only marks the part; the browser's CDN audio
                         # fetch is still in flight. Clicking Next Chapter now can abort that
@@ -865,7 +1116,7 @@ def run():
                     no_new_parts_count = 0 # Reset counter if new parts were found
 
             print(f"Forward pass complete. Total unique parts found: {len(downloaded_parts)}")
-            print(f"Highest part number found: {max_part_number_found}")
+            print(f"Highest part number downloaded: {max_part_number_found}; highest part number seen in any trigger: {max_part_number_seen}")
 
             # --- Wait for all active downloads to complete before proceeding ---
             print("Waiting for all active downloads to complete...")
@@ -880,8 +1131,13 @@ def run():
 
             # --- Step 4: Retrieve Missing Parts via Signed URL Extraction ---
             print("Checking for any missing parts and attempting to retrieve them...")
+            # Range over the highest part SEEN, not just downloaded: parts skipped by
+            # chapter jumps were never accepted, so max_part_number_found alone would
+            # undercount and silently declare success with parts missing (e.g. a run
+            # that downloaded 1-8 but saw triggers for 11 is missing 9-11, not "done").
+            highest_known_part = max(max_part_number_found, max_part_number_seen)
             missing_parts = []
-            for i in range(1, max_part_number_found + 1):
+            for i in range(1, highest_known_part + 1):
                 if i not in downloaded_parts:
                     missing_parts.append(i)
 
@@ -907,7 +1163,7 @@ def run():
                         break
 
                 # Try to extract all signed spine URLs from the player's JavaScript
-                if player_frame_obj and len(_signed_spine_urls) < max_part_number_found:
+                if player_frame_obj and len(_signed_spine_urls) < highest_known_part:
                     print("Extracting signed spine URLs from player...")
                     try:
                         spine_data = player_frame_obj.evaluate(r"""
@@ -1032,4 +1288,13 @@ def run():
 
 # --- How to Run ---
 if __name__ == "__main__":
-    run()
+    with open(RUN_LOG_FILE, 'w') as _log:
+        _log_file = _log
+        sys.stdout = _Tee(sys.__stdout__, _log)
+        sys.stderr = _Tee(sys.__stderr__, _log)
+        try:
+            run()
+        finally:
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+            _log_file = None


### PR DESCRIPTION
## Summary

Fixes #3 and #6, plus the reliability work needed to verify them end to end against real audiobooks.

### Download folder structure (#3)
- Parts are saved to `<download dir>/<Author>/<Title>/Part_NN.mp3`, with names sanitized for the filesystem.

### Missing part recovery (#6)
- Part triggers are only accepted in strict ascending order, so the player's resume-position jump and chapter overshoots can't mis-pair audio onto the wrong part file (previously this could save e.g. Part 5's audio as `Part_01.mp3`).
- Gap recovery: when a Next Chapter jump skips over a part (chapters can span multiple audio parts), the script steps back to before the missing part, then binary-searches Libby's seekometer — the draggable tape scrubber that spans the whole book at 2px/sec — for the part boundary. Missing parts are found in 1–2 probes instead of playing through the chapter in 15-second skips (an 88-minute chapter needed ~350). The 15s-skip loop remains as a fallback, budgeted from the chapter length in the Next Chapter label.
- Probes classify by the tape's settled position and wait for the trigger stream to go quiet, since scrubbing fires triggers for parts merely passed over.
- After recovery, the script waits for in-flight CDN downloads to settle before navigating away, so a recovered part's fetch isn't aborted by the next chapter jump.
- The missing-part check ranges over the highest part *seen in any trigger*, not just downloaded, so a run can't declare success while skipped parts are outstanding. A final retry pass evicts missing parts from the order gate and re-fetches via cached signed spine URLs or a systematic rescan.

### Navigation and end-of-book detection
- Rewind to the beginning before scanning, using Libby's history-back button as a shortcut when it points near the start.
- Forward navigation uses only the player iframe's `Next Chapter` button (aria-label match); the old fallback selectors matched hidden DOM elements at the end of the book and kept the loop spinning forever.
- End of book is detected when the Next Chapter button disappears/goes hidden, with the button's metadata logged every iteration.

### Observability and unattended runs
- All output is teed to `libby_run.log`; noisy unmatched-CDN diagnostics go only to the log, keeping the console readable.
- Full-page screenshots + page/player-iframe HTML snapshots are saved at key screens (shelf, player, gap recovery, end of book) under `snapshots/` for offline DOM inspection.
- `LIBBY_BOOK_TITLE=<title>` preselects a shelf book by name for unattended runs (shelf order isn't stable, so numeric selection is unsafe).
- Skip re-downloading parts already on disk when the size matches the remote (1-byte range probe); force full downloads (`Range: bytes=0-`) so seek-triggered 206 partials can't truncate files.
- Card-usage options are only printed when not already saved in config; audiobook auto-select only happens when there is exactly one book on the shelf.

## Test plan
- [x] Downloaded "Wicked" (24 parts, ~19.5 h) end to end unattended: correct `Gregory Maguire/Wicked/` folder, all 24 parts present, five gap recoveries via seekometer binary search (1–2 probes each), clean end-of-book stop, "No missing parts detected", exit 0
- [x] Re-ran with parts on disk: existing parts skipped by size check
- [x] Verified the retry pass recovers a part whose CDN fetch was aborted mid-run
- [x] Verified false-success bug fixed: runs missing unaccepted parts now report them instead of declaring success
