### PR TITLE
Improve shelf errors when a title is on loan as an ebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Python script automates the process of logging into Libby (libbyapp.com), n
 * Lists audiobooks on your shelf for interactive selection.
 * Downloads individual MP3 parts of the selected audiobook.
 * Attempts to retrieve any missing parts by navigating backward in the player.
+* Organizes downloads in Libation-style folders: `{Author fileAs}/{Series}/{#}_{Title}/Part_NN.mp3` when series metadata is available, otherwise `{Author fileAs}/{Title}/`. Colons and other unsafe characters are stripped from folder names for Android MTP compatibility.
 * Configuration details (library card, PIN, library name, download directory) are stored securely in a `libby_config.json` file after the first run.
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Python script automates the process of logging into Libby (libbyapp.com), n
 * Downloads individual MP3 parts of the selected audiobook.
 * Attempts to retrieve any missing parts by navigating backward in the player.
 * Organizes downloads in Libation-style folders: `{Author fileAs}/{Series}/{#}_{Title}/Part_NN.mp3` when series metadata is available, otherwise `{Author fileAs}/{Title}/`. Colons and other unsafe characters are stripped from folder names for Android MTP compatibility.
+* Downloads the cover image from OverDrive metadata into each book folder as `cover.jpg` (or `.png`/`.webp`).
 * Configuration details (library card, PIN, library name, download directory) are stored securely in a `libby_config.json` file after the first run.
 
 ## Prerequisites

--- a/libby_download.py
+++ b/libby_download.py
@@ -277,11 +277,356 @@ def normalize_text(text):
 
 
 def sanitize_filename(name):
-    """Remove or replace characters that are invalid in directory/file names."""
-    sanitized = re.sub(r'[<>:"/\\|?*]', '_', name)
+    """Remove characters unsafe for paths (colons break Android MTP transfers)."""
+    if not name:
+        return ""
+    sanitized = name.replace(':', '')
+    sanitized = re.sub(r'[<>"/\\|?*]', '_', sanitized)
     sanitized = sanitized.strip().strip('.')
     sanitized = re.sub(r'[_\s]+', ' ', sanitized)
     return sanitized.strip()
+
+
+def extract_title_id_from_tile(tile):
+    """Parse Libby title ID from a shelf tile's data-title_* class."""
+    try:
+        class_attr = tile.get_attribute('class') or ''
+        match = re.search(r'data-title_(\d+)', class_attr)
+        if match:
+            return match.group(1)
+    except Exception:
+        pass
+    return None
+
+
+def _creator_is_author(role):
+    return (role or '').lower() in ('author', 'aut')
+
+
+def display_name_to_file_as(name):
+    """Best-effort 'First Last' -> 'Last, First' when OverDrive fileAs is missing."""
+    name = normalize_text(name)
+    if not name:
+        return ''
+    if ',' in name:
+        return name
+    parts = name.split()
+    if len(parts) < 2:
+        return name
+    return f"{parts[-1]}, {' '.join(parts[:-1])}"
+
+
+def parse_file_as(file_as):
+    """Split OverDrive fileAs into Last, Title, First, Middle name parts."""
+    file_as = normalize_text(file_as)
+    if not file_as:
+        return {'last': '', 'title': '', 'first': '', 'middle': ''}
+    if ',' not in file_as:
+        parts = file_as.split()
+        return {'last': parts[-1] if parts else '', 'title': '', 'first': ' '.join(parts[:-1]), 'middle': ''}
+    last, _, rest = file_as.partition(',')
+    rest = rest.strip()
+    rest_parts = rest.split() if rest else []
+    return {
+        'last': last.strip(),
+        'title': '',
+        'first': rest_parts[0] if rest_parts else '',
+        'middle': ' '.join(rest_parts[1:]) if len(rest_parts) > 1 else '',
+    }
+
+
+def _first_author_from_creators(creators):
+    """Return (display_name, file_as) for the first author in a creators list."""
+    if not creators:
+        return '', ''
+    for creator in creators:
+        if not isinstance(creator, dict):
+            continue
+        if not _creator_is_author(creator.get('role')):
+            continue
+        display = normalize_text(creator.get('name') or '')
+        file_as = normalize_text(
+            creator.get('fileAs') or creator.get('file_as') or creator.get('sortName') or ''
+        )
+        if not file_as and display:
+            file_as = display_name_to_file_as(display)
+        return display, file_as
+    return '', ''
+
+
+def _media_records_from_payload(payload):
+    """Yield media/title dicts from assorted OverDrive API response shapes."""
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                yield item
+        return
+    if not isinstance(payload, dict):
+        return
+    for key in ('titles', 'items', 'media', 'products'):
+        value = payload.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    yield item
+            return
+    if any(k in payload for k in ('title', 'series', 'creators', 'creator', 'readingOrder', 'detailedSeries')):
+        yield payload
+
+
+def parse_overdrive_media_item(item, title_id=None):
+    """Extract Libation-relevant metadata from one OverDrive media object."""
+    if not isinstance(item, dict):
+        return None
+
+    if title_id is not None:
+        item_ids = [
+            str(item.get('id', '')),
+            str(item.get('crossRefId', '')),
+            str(item.get('titleId', '')),
+        ]
+        if str(title_id) not in item_ids and title_id not in item_ids:
+            pass  # still try — bulk responses may use different id fields
+
+    title = normalize_text(item.get('title') or '')
+    if not title and isinstance(item.get('title'), dict):
+        title_obj = item['title']
+        title = normalize_text(title_obj.get('main') or title_obj.get('title') or '')
+
+    series_name = normalize_text(item.get('series') or '')
+    if not series_name and isinstance(item.get('series'), dict):
+        series_name = normalize_text(item['series'].get('name') or item['series'].get('title') or '')
+
+    series_index = item.get('readingOrder') or item.get('seriesIndex') or item.get('sequence')
+    detailed_series = item.get('detailedSeries')
+    if isinstance(detailed_series, dict):
+        if not series_name:
+            series_name = normalize_text(detailed_series.get('seriesName') or detailed_series.get('name') or '')
+        if not series_index:
+            series_index = detailed_series.get('readingOrder') or detailed_series.get('rank')
+    if series_index is not None:
+        series_index = normalize_text(str(series_index))
+
+    creators = item.get('creators') or item.get('creator') or []
+    if isinstance(creators, dict):
+        creators = [creators]
+    author_name, author_file_as = _first_author_from_creators(creators)
+
+    if not author_name and isinstance(item.get('primaryCreator'), dict):
+        pc = item['primaryCreator']
+        if _creator_is_author(pc.get('role')):
+            author_name = normalize_text(pc.get('name') or '')
+            author_file_as = normalize_text(
+                pc.get('fileAs') or pc.get('sortName') or ''
+            ) or display_name_to_file_as(author_name)
+
+    if not author_file_as:
+        author_file_as = normalize_text(
+            item.get('firstCreatorSortName') or ''
+        ) or display_name_to_file_as(author_name)
+
+    if not title and not author_name and not series_name:
+        return None
+
+    return {
+        'title': title,
+        'author_name': author_name,
+        'author_file_as': author_file_as,
+        'series_name': series_name,
+        'series_index': series_index or '',
+    }
+
+
+def parse_overdrive_api_payload(payload, title_id=None):
+    """Parse the best matching media record from an OverDrive JSON response."""
+    best = None
+    for item in _media_records_from_payload(payload):
+        parsed = parse_overdrive_media_item(item, title_id=title_id)
+        if not parsed:
+            continue
+        if title_id is not None:
+            item_ids = {str(item.get('id', '')), str(item.get('crossRefId', '')), str(item.get('titleId', ''))}
+            if str(title_id) in item_ids:
+                return parsed
+        best = best or parsed
+    return best
+
+
+def _parse_captured_overdrive_responses(captured, title_id=None):
+    """Pick the richest metadata record from captured API responses."""
+    bulk_parsed = None
+    fallback_parsed = None
+    for url, payload in captured:
+        parsed = parse_overdrive_api_payload(payload, title_id=title_id)
+        if not parsed:
+            continue
+        if '/media/bulk' in url:
+            if title_id is None or parsed.get('title'):
+                bulk_parsed = parsed
+        elif not fallback_parsed:
+            fallback_parsed = parsed
+    return bulk_parsed or fallback_parsed
+
+
+def scrape_series_from_dom(page):
+    """DOM fallback: read series block on Libby title details if API data is missing."""
+    series_name = ''
+    series_index = ''
+    try:
+        series_heading = page.locator('h2, h3').filter(has_text=re.compile(r'^Series$', re.I))
+        if series_heading.count() > 0:
+            block = series_heading.first.locator('xpath=ancestor::div[contains(@class,"block") or contains(@class,"strap")][1]')
+            if block.count() == 0:
+                block = series_heading.first.locator('xpath=..')
+            text = normalize_text(block.first.inner_text())
+            lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+            for line in lines:
+                if line.lower() == 'series':
+                    continue
+                num_match = re.match(r'^#?(\d+(?:\.\d+)?)\s+(.+)$', line)
+                if num_match and ('★' in line or '☆' in line or '*' in line):
+                    series_index = num_match.group(1)
+                    series_name = normalize_text(num_match.group(2).replace('★', '').replace('☆', '').replace('*', ''))
+                    break
+                if not series_name and line.lower() != 'series':
+                    series_name = line
+    except Exception as e:
+        print(f"  [metadata] DOM series scrape failed: {e}")
+    return series_name, series_index
+
+
+def scrape_authors_from_dom(page):
+    """DOM fallback: first linked author name on title details."""
+    for selector in (
+        '.title-details-author a',
+        '.biblio-author a',
+        '.title-tile-author a',
+        '[class*="author"] a',
+    ):
+        try:
+            links = page.locator(selector)
+            if links.count() > 0:
+                name = normalize_text(links.first.text_content())
+                if name:
+                    return name, display_name_to_file_as(name)
+        except Exception:
+            continue
+    return '', ''
+
+
+def build_book_download_dir(base_dir, metadata, fallback_title, fallback_author=''):
+    """Libation-style path: {fileAs}/{series}/{n}_{title}/ or {fileAs}/{title}/."""
+    title = sanitize_filename(metadata.get('title') or fallback_title)
+    author_folder = sanitize_filename(
+        metadata.get('author_file_as') or display_name_to_file_as(metadata.get('author_name') or '')
+        or fallback_author
+    )
+
+    series_name = sanitize_filename(metadata.get('series_name') or '')
+    series_index = sanitize_filename(metadata.get('series_index') or '')
+
+    if series_name:
+        if series_index:
+            book_folder = (
+                f"{sanitize_filename(series_index)}_"
+                f"{sanitize_filename(metadata.get('title') or fallback_title)}"
+            )
+        else:
+            book_folder = title
+        parts = [base_dir]
+        if author_folder:
+            parts.append(author_folder)
+        parts.extend([series_name, book_folder])
+    else:
+        parts = [base_dir]
+        if author_folder:
+            parts.append(author_folder)
+        parts.append(title)
+
+    return os.path.join(*parts)
+
+
+def fetch_title_metadata(page, tile, fallback_title, fallback_author='', title_id=None):
+    """Open title details, capture OverDrive API metadata, return to shelf."""
+    if title_id is None:
+        title_id = extract_title_id_from_tile(tile)
+
+    captured = []
+
+    def on_response(response):
+        url = response.url
+        if response.status != 200:
+            return
+        if 'overdrive.com' not in url:
+            return
+        if not any(token in url for token in ('media', 'titles', 'products', 'bulk')):
+            return
+        try:
+            payload = response.json()
+        except Exception:
+            return
+        captured.append((url, payload))
+        log_only(f"  [metadata] captured API response: {url}")
+
+    page.on('response', on_response)
+    metadata = {
+        'title': fallback_title,
+        'author_name': fallback_author,
+        'author_file_as': display_name_to_file_as(fallback_author),
+        'series_name': '',
+        'series_index': '',
+    }
+
+    try:
+        title_link = tile.locator('a.title-tile-action').first
+        print(f"Opening title details for metadata (title id={title_id})...")
+        title_link.click(timeout=10000)
+        try:
+            page.wait_for_load_state('networkidle', timeout=15000)
+        except PlaywrightTimeoutError:
+            pass
+        time.sleep(2)
+        save_snapshot(page, 'title_details')
+
+        parsed = _parse_captured_overdrive_responses(captured, title_id=title_id)
+        if parsed:
+            print("  [metadata] parsed from OverDrive API")
+            metadata.update({k: v for k, v in parsed.items() if v})
+        else:
+            print("  [metadata] no OverDrive API metadata captured; trying DOM fallback.")
+            dom_author, dom_file_as = scrape_authors_from_dom(page)
+            dom_series, dom_index = scrape_series_from_dom(page)
+            if dom_author:
+                metadata['author_name'] = dom_author
+                metadata['author_file_as'] = dom_file_as
+            if dom_series:
+                metadata['series_name'] = dom_series
+            if dom_index:
+                metadata['series_index'] = dom_index
+
+        print(
+            f"  [metadata] author={metadata.get('author_file_as')!r} "
+            f"series={metadata.get('series_name')!r} index={metadata.get('series_index')!r}"
+        )
+    except Exception as e:
+        print(f"  [metadata] title details fetch failed ({e}); using shelf fallbacks.")
+    finally:
+        try:
+            page.remove_listener('response', on_response)
+        except Exception:
+            pass
+        try:
+            page.go_back()
+            try:
+                page.wait_for_load_state('networkidle', timeout=15000)
+            except PlaywrightTimeoutError:
+                pass
+            time.sleep(2)
+            page.wait_for_selector('.title-list-tiles .title-tile', timeout=15000)
+        except Exception as e:
+            print(f"  [metadata] warning: could not return to shelf cleanly: {e}")
+
+    return metadata
 
 # --- Network Request Handler ---
 def handle_request(request):
@@ -840,25 +1185,33 @@ def run():
                         except ValueError:
                             print("Invalid input. Please enter a number.")
 
-                # Create a book-specific download subdirectory (Author/Title or just Title)
+                # Fetch series/author metadata from title details before opening the player.
+                selected_tile = page.locator(
+                    '.title-list-tiles .title-tile.data-title-tile-format_audiobook'
+                ).nth(choice_index)
                 selected_author = audiobook_authors[choice_index] if choice_index < len(audiobook_authors) else ""
-                book_folder_name = sanitize_filename(selected_title)
-                if selected_author:
-                    author_folder_name = sanitize_filename(selected_author)
-                    book_download_dir = os.path.join(config['DOWNLOAD_DIRECTORY'], author_folder_name, book_folder_name)
-                    print(f"Author: '{selected_author}' -> folder: '{author_folder_name}'")
-                else:
-                    book_download_dir = os.path.join(config['DOWNLOAD_DIRECTORY'], book_folder_name)
-                    print("No author info found on shelf tile; using title-only folder.")
+                title_metadata = fetch_title_metadata(
+                    page,
+                    selected_tile,
+                    fallback_title=selected_title,
+                    fallback_author=selected_author,
+                )
 
-                os.makedirs(book_download_dir, exist_ok=True)
+                book_download_dir = build_book_download_dir(
+                    config['DOWNLOAD_DIRECTORY'],
+                    title_metadata,
+                    fallback_title=selected_title,
+                    fallback_author=selected_author,
+                )
                 print(f"Download directory for this book: {book_download_dir}")
+                os.makedirs(book_download_dir, exist_ok=True)
                 config['DOWNLOAD_DIRECTORY'] = book_download_dir
+                book_folder_name = os.path.basename(book_download_dir)
 
                 # Open the tile the user picked by index - not by title text. Libby titles
                 # often contain non-breaking spaces that break :has-text() matching.
                 open_audiobook_button_selector = """button[role="button"]:has-text("Open Audiobook")"""
-                page.locator('.title-list-tiles .title-tile.data-title-tile-format_audiobook').nth(choice_index).locator(open_audiobook_button_selector).click(timeout=10000)
+                selected_tile.locator(open_audiobook_button_selector).click(timeout=10000)
                 try:
                     page.wait_for_load_state('networkidle', timeout=15000)
                 except PlaywrightTimeoutError:

--- a/libby_download.py
+++ b/libby_download.py
@@ -316,6 +316,22 @@ def display_name_to_file_as(name):
     return f"{parts[-1]}, {' '.join(parts[:-1])}"
 
 
+def _best_cover_url_from_item(item):
+    """Pick the largest available cover image URL from an OverDrive media object."""
+    if not isinstance(item, dict):
+        return ''
+    covers = item.get('covers') or {}
+    if not isinstance(covers, dict):
+        return ''
+    for key in ('cover510Wide', 'cover300Wide', 'cover150Wide', 'cover'):
+        entry = covers.get(key)
+        if isinstance(entry, dict):
+            href = normalize_text(entry.get('href') or '')
+            if href:
+                return href
+    return ''
+
+
 def parse_file_as(file_as):
     """Split OverDrive fileAs into Last, Title, First, Middle name parts."""
     file_as = normalize_text(file_as)
@@ -434,6 +450,7 @@ def parse_overdrive_media_item(item, title_id=None):
         'author_file_as': author_file_as,
         'series_name': series_name,
         'series_index': series_index or '',
+        'cover_url': _best_cover_url_from_item(item),
     }
 
 
@@ -466,6 +483,50 @@ def _parse_captured_overdrive_responses(captured, title_id=None):
         elif not fallback_parsed:
             fallback_parsed = parsed
     return bulk_parsed or fallback_parsed
+
+
+def scrape_cover_from_dom(page):
+    """DOM fallback: find cover image URL on Libby title details."""
+    selectors = (
+        'img[src*="od-cdn.com"]',
+        '.title-details-cover img',
+        '.cover img',
+        '[class*="cover"] img',
+    )
+    for selector in selectors:
+        try:
+            imgs = page.locator(selector)
+            if imgs.count() > 0:
+                src = normalize_text(imgs.first.get_attribute('src') or '')
+                if src.startswith('http'):
+                    return src
+        except Exception:
+            continue
+    return ''
+
+
+def download_cover_image(cover_url, dest_dir):
+    """Download cover art into dest_dir as cover.jpg (or .png/.webp from content-type)."""
+    if not cover_url:
+        return None
+    try:
+        response = requests.get(cover_url, timeout=30)
+        response.raise_for_status()
+        content_type = (response.headers.get('content-type') or '').lower()
+        if 'png' in content_type:
+            ext = '.png'
+        elif 'webp' in content_type:
+            ext = '.webp'
+        else:
+            ext = '.jpg'
+        cover_path = os.path.join(dest_dir, f'cover{ext}')
+        with open(cover_path, 'wb') as f:
+            f.write(response.content)
+        print(f"Downloaded cover art to {cover_path}")
+        return cover_path
+    except Exception as e:
+        print(f"Cover art download failed: {e}")
+        return None
 
 
 def scrape_series_from_dom(page):
@@ -575,6 +636,7 @@ def fetch_title_metadata(page, tile, fallback_title, fallback_author='', title_i
         'author_file_as': display_name_to_file_as(fallback_author),
         'series_name': '',
         'series_index': '',
+        'cover_url': '',
     }
 
     try:
@@ -596,6 +658,7 @@ def fetch_title_metadata(page, tile, fallback_title, fallback_author='', title_i
             print("  [metadata] no OverDrive API metadata captured; trying DOM fallback.")
             dom_author, dom_file_as = scrape_authors_from_dom(page)
             dom_series, dom_index = scrape_series_from_dom(page)
+            dom_cover = scrape_cover_from_dom(page)
             if dom_author:
                 metadata['author_name'] = dom_author
                 metadata['author_file_as'] = dom_file_as
@@ -603,6 +666,8 @@ def fetch_title_metadata(page, tile, fallback_title, fallback_author='', title_i
                 metadata['series_name'] = dom_series
             if dom_index:
                 metadata['series_index'] = dom_index
+            if dom_cover:
+                metadata['cover_url'] = dom_cover
 
         print(
             f"  [metadata] author={metadata.get('author_file_as')!r} "
@@ -1205,6 +1270,7 @@ def run():
                 )
                 print(f"Download directory for this book: {book_download_dir}")
                 os.makedirs(book_download_dir, exist_ok=True)
+                download_cover_image(title_metadata.get('cover_url'), book_download_dir)
                 config['DOWNLOAD_DIRECTORY'] = book_download_dir
                 book_folder_name = os.path.basename(book_download_dir)
 

--- a/libby_download.py
+++ b/libby_download.py
@@ -220,6 +220,62 @@ def save_config(config_data):
         json.dump(config_data, f, indent=4)
     print(f"Saved configuration to {CONFIG_FILE}.")
 
+def collect_shelf_titles(page, format_class):
+    """Return (titles, authors) for shelf tiles of the given Libby format class."""
+    tiles = page.locator(f'.title-list-tiles .title-tile.{format_class}').all()
+    titles = []
+    authors = []
+    for tile in tiles:
+        title_element = tile.locator('.title-tile-title').first
+        if title_element:
+            titles.append(normalize_text(title_element.text_content()))
+
+        author_text = ""
+        for author_selector in ['.title-tile-author', '.title-tile-creator', '.title-tile-subtitle']:
+            try:
+                author_element = tile.locator(author_selector).first
+                if author_element and author_element.is_visible():
+                    candidate = normalize_text(author_element.text_content())
+                    if candidate:
+                        author_text = candidate
+                        break
+            except Exception:
+                continue
+        authors.append(author_text)
+    return titles, authors
+
+
+def title_matches(requested, candidate):
+    """Case-insensitive substring match between a requested title and a shelf title."""
+    if not requested or not candidate:
+        return False
+    req = requested.lower()
+    cand = candidate.lower()
+    return req in cand or cand in req
+
+
+def explain_missing_audiobook(page, requested_title):
+    """If the user asked for a title that is on loan as an ebook, say so plainly."""
+    ebook_titles, _ = collect_shelf_titles(page, 'data-title-tile-format_book')
+    for ebook_title in ebook_titles:
+        if title_matches(requested_title, ebook_title):
+            print(f"\nCannot download '{requested_title}': that title is on your shelf as an ebook, not an audiobook.")
+            print("This script only downloads audiobooks (MP3 parts from the Libby player).")
+            print("In Libby, search for the title again and borrow the audiobook edition (headphones icon),")
+            print("then re-run this script once it appears on your shelf with 'Open Audiobook'.")
+            return True
+    print(f"\n'{requested_title}' was not found as an audiobook on your shelf.")
+    print("Make sure you've borrowed the audiobook edition and it shows 'Open Audiobook' in Libby.")
+    return False
+
+
+def normalize_text(text):
+    """Collapse Libby's non-breaking spaces and HTML entities into normal spaces."""
+    if not text:
+        return ""
+    return text.replace('\xa0', ' ').replace('&nbsp;', ' ').strip()
+
+
 def sanitize_filename(name):
     """Remove or replace characters that are invalid in directory/file names."""
     sanitized = re.sub(r'[<>:"/\\|?*]', '_', name)
@@ -720,53 +776,50 @@ def run():
             print("\nAudiobooks on your Shelf:")
             save_snapshot(page, "shelf")
             try:
-                # Wait for audiobook tiles to be visible
+                # Only audiobook tiles can be opened in the Libby player. Ebook loans use
+                # "Read With..." and are listed separately so users know why a title is missing.
                 page.wait_for_selector('.title-list-tiles .title-tile', timeout=15000)
 
-                audiobook_tiles = page.locator('.title-list-tiles .title-tile').all()
-                audiobook_titles = []
-                audiobook_authors = []
-                for i, tile in enumerate(audiobook_tiles):
-                    title_element = tile.locator('.title-tile-title').first
-                    if title_element:
-                        title_text = title_element.text_content().strip().replace('&nbsp;', ' ')
-                        audiobook_titles.append(title_text)
-
-                    author_text = ""
-                    for author_selector in ['.title-tile-author', '.title-tile-creator', '.title-tile-subtitle']:
-                        try:
-                            author_element = tile.locator(author_selector).first
-                            if author_element and author_element.is_visible():
-                                candidate = author_element.text_content().strip().replace('&nbsp;', ' ')
-                                if candidate:
-                                    author_text = candidate
-                                    break
-                        except Exception:
-                            continue
-                    audiobook_authors.append(author_text)
+                audiobook_titles, audiobook_authors = collect_shelf_titles(page, 'data-title-tile-format_audiobook')
+                ebook_titles, _ = collect_shelf_titles(page, 'data-title-tile-format_book')
 
                 print(f"DEBUG: Parsed Audiobook Titles: {audiobook_titles}")
                 print(f"DEBUG: Parsed Audiobook Authors: {audiobook_authors}")
+                if ebook_titles:
+                    print(f"DEBUG: Ebook-only loans on shelf (not downloadable here): {ebook_titles}")
 
                 if not audiobook_titles:
                     print("No audiobooks found on your shelf.")
+                    preselect_title = normalize_text(os.environ.get('LIBBY_BOOK_TITLE', ''))
+                    if preselect_title:
+                        explain_missing_audiobook(page, preselect_title)
+                    elif ebook_titles:
+                        print("\nYou do have ebook loans on your shelf, but this script only downloads audiobooks:")
+                        for title in ebook_titles:
+                            print(f"  - {title} (ebook)")
                     return
 
-                # Prompt user for which book on their shelf they want to download.
-                # Print numbered list for user selection
+                # Prompt user for which audiobook on their shelf they want to download.
                 for i, title in enumerate(audiobook_titles):
                     print(f"{i+1}. {title}")
+                if ebook_titles:
+                    print("\nEbook loans on your shelf (not supported by this script):")
+                    for title in ebook_titles:
+                        print(f"  - {title}")
 
                 # Non-interactive preselect by title (for unattended/testing runs):
                 # LIBBY_BOOK_TITLE=Wicked picks the first shelf title containing the
                 # string, case-insensitively. Shelf order is not stable, so piping a
                 # number into stdin can select the wrong book.
-                preselect_title = os.environ.get('LIBBY_BOOK_TITLE', '').strip()
-                preselect_matches = [i for i, t in enumerate(audiobook_titles) if preselect_title and preselect_title.lower() in t.lower()]
+                preselect_title = normalize_text(os.environ.get('LIBBY_BOOK_TITLE', ''))
+                preselect_matches = [i for i, t in enumerate(audiobook_titles) if preselect_title and title_matches(preselect_title, t)]
                 if preselect_matches:
                     choice_index = preselect_matches[0]
                     selected_title = audiobook_titles[choice_index]
                     print(f"Preselected via LIBBY_BOOK_TITLE={preselect_title!r}: '{selected_title}'")
+                elif preselect_title:
+                    explain_missing_audiobook(page, preselect_title)
+                    return
                 # Select audiobook (auto-select only when there's a single option)
                 elif AUTO_SELECT_FIRST_AUDIOBOOK and len(audiobook_titles) == 1:
                     choice_index = 0
@@ -802,19 +855,21 @@ def run():
                 print(f"Download directory for this book: {book_download_dir}")
                 config['DOWNLOAD_DIRECTORY'] = book_download_dir
 
-                # Locate the specific audiobook tile using the selected title
-                audiobook_tile_locator = page.locator(f"""div.title-tile:has-text("{selected_title}")""").first
-                # Click the "Open Audiobook" button within that tile
+                # Open the tile the user picked by index - not by title text. Libby titles
+                # often contain non-breaking spaces that break :has-text() matching.
                 open_audiobook_button_selector = """button[role="button"]:has-text("Open Audiobook")"""
-                audiobook_tile_locator.locator(open_audiobook_button_selector).click()
-                page.wait_for_load_state('networkidle')
+                page.locator('.title-list-tiles .title-tile.data-title-tile-format_audiobook').nth(choice_index).locator(open_audiobook_button_selector).click(timeout=10000)
+                try:
+                    page.wait_for_load_state('networkidle', timeout=15000)
+                except PlaywrightTimeoutError:
+                    pass  # Libby's SPA often never reaches networkidle; the player still loads
                 time.sleep(3)
-                filename = f"15_after_open_audiobook_button_{selected_title.replace(' ', '_')}.png"
+                filename = f"15_after_open_audiobook_button_{book_folder_name.replace(' ', '_')}.png"
                 screenshot_path = os.path.join(config['DOWNLOAD_DIRECTORY'], filename)
                 page.screenshot(path=screenshot_path)
 
-            except PlaywrightTimeoutError:
-                print("Error: Audiobook titles did not appear in time on the shelf.")
+            except PlaywrightTimeoutError as e:
+                print(f"Error: Timed out while opening the selected audiobook on the shelf: {e}")
                 return
             except Exception as e:
                 print(f"An error occurred while listing/selecting audiobooks: {e}")

--- a/test_metadata.py
+++ b/test_metadata.py
@@ -65,6 +65,18 @@ class TestOverdriveParser(unittest.TestCase):
         self.assertEqual(meta['author_file_as'], 'Maguire, Gregory')
         self.assertEqual(meta['series_index'], '1')
 
+    def test_cover_url_from_covers(self):
+        payload = [{
+            'id': '2943031',
+            'title': 'Wicked',
+            'covers': {
+                'cover300Wide': {'href': 'https://img.example/cover300.jpg'},
+                'cover150Wide': {'href': 'https://img.example/cover150.jpg'},
+            },
+        }]
+        meta = parse_overdrive_api_payload(payload, title_id='2943031')
+        self.assertEqual(meta['cover_url'], 'https://img.example/cover300.jpg')
+
 
 class TestBuildPath(unittest.TestCase):
     def test_series_path(self):

--- a/test_metadata.py
+++ b/test_metadata.py
@@ -1,0 +1,105 @@
+"""Unit tests for Libation-style metadata path helpers."""
+import os
+import unittest
+
+from libby_download import (
+    build_book_download_dir,
+    display_name_to_file_as,
+    parse_file_as,
+    parse_overdrive_api_payload,
+    sanitize_filename,
+)
+
+
+class TestSanitizeFilename(unittest.TestCase):
+    def test_strips_colons(self):
+        self.assertEqual(sanitize_filename('Dune: The Duke'), 'Dune The Duke')
+
+    def test_strips_other_unsafe_chars(self):
+        self.assertEqual(sanitize_filename('A/B:C'), 'A BC')
+
+
+class TestFileAs(unittest.TestCase):
+    def test_display_name_to_file_as(self):
+        self.assertEqual(display_name_to_file_as('Gregory Maguire'), 'Maguire, Gregory')
+
+    def test_parse_file_as(self):
+        parts = parse_file_as('Maguire, Gregory')
+        self.assertEqual(parts['last'], 'Maguire')
+        self.assertEqual(parts['first'], 'Gregory')
+
+
+class TestOverdriveParser(unittest.TestCase):
+    def test_bulk_payload(self):
+        payload = {
+            'titles': [{
+                'id': 2943031,
+                'title': 'Wicked',
+                'series': 'Wicked Years',
+                'readingOrder': '1',
+                'creators': [
+                    {'role': 'Author', 'name': 'Gregory Maguire', 'fileAs': 'Maguire, Gregory'},
+                    {'role': 'Narrator', 'name': 'Someone Else'},
+                ],
+            }]
+        }
+        meta = parse_overdrive_api_payload(payload, title_id='2943031')
+        self.assertEqual(meta['author_file_as'], 'Maguire, Gregory')
+        self.assertEqual(meta['series_name'], 'Wicked Years')
+        self.assertEqual(meta['series_index'], '1')
+
+    def test_bulk_array_with_detailed_series(self):
+        payload = [{
+            'id': '2943031',
+            'title': 'Wicked',
+            'series': 'Wicked Years',
+            'detailedSeries': {
+                'seriesName': 'Wicked Years',
+                'readingOrder': '1',
+            },
+            'creators': [
+                {'role': 'Author', 'name': 'Gregory Maguire', 'sortName': 'Maguire, Gregory'},
+            ],
+        }]
+        meta = parse_overdrive_api_payload(payload, title_id='2943031')
+        self.assertEqual(meta['author_file_as'], 'Maguire, Gregory')
+        self.assertEqual(meta['series_index'], '1')
+
+
+class TestBuildPath(unittest.TestCase):
+    def test_series_path(self):
+        base = '/downloads'
+        meta = {
+            'title': 'Wicked',
+            'author_file_as': 'Maguire, Gregory',
+            'series_name': 'Wicked Years',
+            'series_index': '1',
+        }
+        path = build_book_download_dir(base, meta, 'Wicked')
+        self.assertEqual(path, os.path.join(base, 'Maguire, Gregory', 'Wicked Years', '1_Wicked'))
+
+    def test_no_series(self):
+        base = '/downloads'
+        meta = {
+            'title': 'Vilest Things',
+            'author_file_as': 'Gong, Chloe',
+            'series_name': '',
+            'series_index': '',
+        }
+        path = build_book_download_dir(base, meta, 'Vilest Things')
+        self.assertEqual(path, os.path.join(base, 'Gong, Chloe', 'Vilest Things'))
+
+    def test_colon_in_title(self):
+        base = '/downloads'
+        meta = {
+            'title': 'Something: Subtitle',
+            'author_file_as': 'Author, Test',
+            'series_name': '',
+            'series_index': '',
+        }
+        path = build_book_download_dir(base, meta, 'Something: Subtitle')
+        self.assertNotIn(':', path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Filter shelf listing to audiobook loans only; show ebook loans in a separate unnumbered section
- Detect when a requested title matches an ebook on shelf and print a clear message to borrow the audiobook edition
- Normalize non-breaking spaces in Libby titles and open shelf tiles by index instead of `:has-text()` matching

## Test plan
- [x] `LIBBY_BOOK_TITLE="A Parade of Horribles"` with ebook on shelf prints ebook-specific guidance
- [x] Shelf list shows audiobooks numbered and ebooks listed separately

Made with [Cursor](https://cursor.com)